### PR TITLE
Clean up listener lifecycle management

### DIFF
--- a/src/main/java/me/lele/worldSafe/WorldSafe.java
+++ b/src/main/java/me/lele/worldSafe/WorldSafe.java
@@ -26,6 +26,7 @@ import me.lele.worldSafe.listener.entities.other.EnderManBlockPickupProtectionLi
 import me.lele.worldSafe.listener.entities.other.PhantomDamagePreventionListener;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.command.CommandSender;
+import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.spongepowered.configurate.serialize.SerializationException;
@@ -37,7 +38,7 @@ import java.util.function.Function;
 
 public final class WorldSafe extends JavaPlugin {
 
-	public static List<Listener> listeners = new ArrayList<>();
+        private final List<Listener> listeners = new ArrayList<>();
 	public static ConfigManager configManager;
 	private LiteCommands<CommandSender> liteCommands;
 
@@ -74,11 +75,13 @@ public final class WorldSafe extends JavaPlugin {
 
 	}
 
-	@Override
-	public void onDisable() {
-		getLogger().info("插件已卸载!");
-		// Plugin shutdown logic
-	}
+        @Override
+        public void onDisable() {
+                getLogger().info("插件已卸载!");
+                // Plugin shutdown logic
+                HandlerList.unregisterAll(this);
+                listeners.clear();
+        }
 
 	public void loadFeatures() throws SerializationException {
 		// 获取配置文件中的总开关
@@ -144,6 +147,10 @@ public final class WorldSafe extends JavaPlugin {
                 Listener listener = factory.apply(worlds);
                 getServer().getPluginManager().registerEvents(listener, this);
                 listeners.add(listener);
+        }
+
+        public List<Listener> getListeners() {
+                return listeners;
         }
 
 

--- a/src/main/java/me/lele/worldSafe/command/WorldSafeCommand.java
+++ b/src/main/java/me/lele/worldSafe/command/WorldSafeCommand.java
@@ -10,7 +10,6 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 
 import static me.lele.worldSafe.WorldSafe.configManager;
-import static me.lele.worldSafe.WorldSafe.listeners;
 
 @Command(name = "worldsafe")
 @Permission("worldsafe.admin")
@@ -39,11 +38,11 @@ public class WorldSafeCommand {
         //套上线程同步锁,保证重载期间服务器停止处理,避免有生物在重载的几毫秒时间里破坏方块
         synchronized (this) {
             //重载监听器
-            for (Listener listener : listeners) {
+            for (Listener listener : plugin.getListeners()) {
                 HandlerList.unregisterAll(listener);
             }
             // 清空监听器列表
-            listeners.clear();
+            plugin.getListeners().clear();
             //重新注册监听器
             plugin.reloadFeatures();
         }


### PR DESCRIPTION
## Summary
- unregister plugin listeners on disable and clear the registry for safe reloads
- convert the listener registry to an instance field with an accessor for command-based reloads

## Testing
- mvn -q -DskipTests package *(fails: Unable to download maven-resources-plugin from Maven Central - HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68fa1dff5d788330a2d53a588272ba19