### PR TITLE
Add null safety for world checks in protection listeners

### DIFF
--- a/src/main/java/me/lele/worldSafe/listener/blocks/explosioncancel/BedExplosionCancelListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/blocks/explosioncancel/BedExplosionCancelListener.java
@@ -2,6 +2,7 @@ package me.lele.worldSafe.listener.blocks.explosioncancel;
 
 import org.bukkit.World;
 import org.bukkit.World.Environment;
+import org.bukkit.block.Block;
 import org.bukkit.block.data.type.Bed;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -26,19 +27,29 @@ public class BedExplosionCancelListener implements Listener {
 		// 检查玩家点击的是否为方块
 		if (!e.hasBlock())
 			return;
-		World w = e.getClickedBlock().getWorld();
-		// 判断是否在主世界触发
-		if (w.getEnvironment() == Environment.NORMAL)
-			return;
-		// 检查玩家点击的是否为床
-		if (!(e.getClickedBlock().getBlockData() instanceof Bed))
-			return;
-		// 判断是否启用这个世界
-		if (!worlds.contains(w.getName()))
-			return;
-		// 取消事件，防止爆炸
-		e.setCancelled(true);
+                Block clickedBlock = e.getClickedBlock();
+                if (clickedBlock == null)
+                        return;
+                World w = getWorld(clickedBlock);
+                if (!isWorldEnabled(w))
+                        return;
+                // 判断是否在主世界触发
+                if (w.getEnvironment() == Environment.NORMAL)
+                        return;
+                // 检查玩家点击的是否为床
+                if (!(clickedBlock.getBlockData() instanceof Bed))
+                        return;
+                // 取消事件，防止爆炸
+                e.setCancelled(true);
 
-	}
+        }
+
+        private World getWorld(Block block) {
+                return block != null ? block.getWorld() : null;
+        }
+
+        private boolean isWorldEnabled(World world) {
+                return world != null && worlds.contains(world.getName());
+        }
 
 }

--- a/src/main/java/me/lele/worldSafe/listener/blocks/explosioncancel/RespawnAnchorExplosionCancelListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/blocks/explosioncancel/RespawnAnchorExplosionCancelListener.java
@@ -1,6 +1,9 @@
 package me.lele.worldSafe.listener.blocks.explosioncancel;
 
+import org.bukkit.Location;
+import org.bukkit.World;
 import org.bukkit.Material;
+import org.bukkit.block.BlockState;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockExplodeEvent;
@@ -18,16 +21,30 @@ public class RespawnAnchorExplosionCancelListener implements Listener {
     @EventHandler
     void onRespawnAnchorExplosion(BlockExplodeEvent e) {
 
+        BlockState explodedBlockState = e.getExplodedBlockState();
+        if (explodedBlockState == null) {
+            return;
+        }
+
         // 检测是否为 重生锚 爆炸
-        if (e.getExplodedBlockState().getBlockData().getMaterial() == Material.RESPAWN_ANCHOR) {
-            // 判断是否启用这个世界
-            if (!worlds.contains(e.getExplodedBlockState().getLocation().getWorld().getName()))
+        if (explodedBlockState.getBlockData().getMaterial() == Material.RESPAWN_ANCHOR) {
+            World world = getWorld(explodedBlockState.getLocation());
+            if (!isWorldEnabled(world)) {
                 return;
+            }
             // 清空爆炸影响的方块
             e.setCancelled(true);
 
         }
 
+    }
+
+    private World getWorld(Location location) {
+        return location != null ? location.getWorld() : null;
+    }
+
+    private boolean isWorldEnabled(World world) {
+        return world != null && worlds.contains(world.getName());
     }
 
 }

--- a/src/main/java/me/lele/worldSafe/listener/blocks/explosioncancel/TNTExplosionCancelListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/blocks/explosioncancel/TNTExplosionCancelListener.java
@@ -1,5 +1,6 @@
 package me.lele.worldSafe.listener.blocks.explosioncancel;
 
+import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
@@ -20,11 +21,19 @@ public class TNTExplosionCancelListener implements Listener {
 		// 检测是否为TNT类实体
 		if (e.getEntityType() != EntityType.TNT && e.getEntityType() != EntityType.TNT_MINECART)
 			return;
-		Entity ent = e.getEntity();
-		// 判断是否启用这个世界
-		if (!worlds.contains(ent.getWorld().getName()))
-			return;
-		// 清空爆炸影响的方块
-		e.setCancelled(true);
-	}
+                Entity ent = e.getEntity();
+                World world = getWorld(ent);
+                if (!isWorldEnabled(world))
+                        return;
+                // 清空爆炸影响的方块
+                e.setCancelled(true);
+        }
+
+        private World getWorld(Entity entity) {
+                return entity != null ? entity.getWorld() : null;
+        }
+
+        private boolean isWorldEnabled(World world) {
+                return world != null && worlds.contains(world.getName());
+        }
 }

--- a/src/main/java/me/lele/worldSafe/listener/blocks/explosionprevention/BedExplosionProtectionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/blocks/explosionprevention/BedExplosionProtectionListener.java
@@ -1,5 +1,8 @@
 package me.lele.worldSafe.listener.blocks.explosionprevention;
 
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.data.type.Bed;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -18,16 +21,30 @@ public class BedExplosionProtectionListener implements Listener {
     @EventHandler
     void onBedExplosion(BlockExplodeEvent e) {
 
+        BlockState explodedBlockState = e.getExplodedBlockState();
+        if (explodedBlockState == null) {
+            return;
+        }
+
         // 检测是否为 床 爆炸
-        if (e.getExplodedBlockState().getBlockData() instanceof Bed){
-            // 判断是否启用这个世界
-            if (!worlds.contains(e.getExplodedBlockState().getLocation().getWorld().getName()))
+        if (explodedBlockState.getBlockData() instanceof Bed){
+            World world = getWorld(explodedBlockState.getLocation());
+            if (!isWorldEnabled(world)) {
                 return;
+            }
             // 清空爆炸影响的方块
             e.blockList().clear();
 
         }
 
+    }
+
+    private World getWorld(Location location) {
+        return location != null ? location.getWorld() : null;
+    }
+
+    private boolean isWorldEnabled(World world) {
+        return world != null && worlds.contains(world.getName());
     }
 
 }

--- a/src/main/java/me/lele/worldSafe/listener/blocks/explosionprevention/RespawnAnchorExplosionPreventionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/blocks/explosionprevention/RespawnAnchorExplosionPreventionListener.java
@@ -1,6 +1,9 @@
 package me.lele.worldSafe.listener.blocks.explosionprevention;
 
+import org.bukkit.Location;
+import org.bukkit.World;
 import org.bukkit.Material;
+import org.bukkit.block.BlockState;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockExplodeEvent;
@@ -18,16 +21,30 @@ public class RespawnAnchorExplosionPreventionListener implements Listener {
     @EventHandler
     void onRespawnAnchorExplosion(BlockExplodeEvent e) {
 
+        BlockState explodedBlockState = e.getExplodedBlockState();
+        if (explodedBlockState == null) {
+            return;
+        }
+
         // 检测是否为 重生锚 爆炸
-        if (e.getExplodedBlockState().getBlockData().getMaterial() == Material.RESPAWN_ANCHOR) {
-            // 判断是否启用这个世界
-            if (!worlds.contains(e.getExplodedBlockState().getLocation().getWorld().getName()))
+        if (explodedBlockState.getBlockData().getMaterial() == Material.RESPAWN_ANCHOR) {
+            World world = getWorld(explodedBlockState.getLocation());
+            if (!isWorldEnabled(world)) {
                 return;
+            }
             // 清空爆炸影响的方块
             e.blockList().clear();
 
         }
 
+    }
+
+    private World getWorld(Location location) {
+        return location != null ? location.getWorld() : null;
+    }
+
+    private boolean isWorldEnabled(World world) {
+        return world != null && worlds.contains(world.getName());
     }
 
 }

--- a/src/main/java/me/lele/worldSafe/listener/blocks/explosionprevention/TNTExplosionProtectionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/blocks/explosionprevention/TNTExplosionProtectionListener.java
@@ -2,6 +2,7 @@ package me.lele.worldSafe.listener.blocks.explosionprevention;
 
 import java.util.List;
 
+import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
@@ -20,11 +21,19 @@ public class TNTExplosionProtectionListener implements Listener {
 		// 检测是否为TNT类实体
 		if (e.getEntityType() != EntityType.TNT && e.getEntityType() != EntityType.TNT_MINECART)
 			return;
-		Entity ent = e.getEntity();
-		// 判断是否启用这个世界
-		if (!worlds.contains(ent.getWorld().getName()))
-			return;
-		// 清空爆炸影响的方块
-		e.blockList().clear();
-	}
+                Entity ent = e.getEntity();
+                World world = getWorld(ent);
+                if (!isWorldEnabled(world))
+                        return;
+                // 清空爆炸影响的方块
+                e.blockList().clear();
+        }
+
+        private World getWorld(Entity entity) {
+                return entity != null ? entity.getWorld() : null;
+        }
+
+        private boolean isWorldEnabled(World world) {
+                return world != null && worlds.contains(world.getName());
+        }
 }

--- a/src/main/java/me/lele/worldSafe/listener/blocks/other/CropTrampleProtectionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/blocks/other/CropTrampleProtectionListener.java
@@ -3,6 +3,7 @@ package me.lele.worldSafe.listener.blocks.other;
 import java.util.List;
 
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -24,10 +25,18 @@ public class CropTrampleProtectionListener implements Listener {
 		// 检测是否为踩踏
 		if (e.getTo() != Material.DIRT && e.getTo() != Material.GRASS_BLOCK)
 			return;
-		// 检测世界是否启用
-		if (!worlds.contains(b.getLocation().getWorld().getName()))
-			return;
-		// 取消事件
-		e.setCancelled(true);
-	}
+                World world = getWorld(b);
+                if (!isWorldEnabled(world))
+                        return;
+                // 取消事件
+                e.setCancelled(true);
+        }
+
+        private World getWorld(Block block) {
+                return block != null ? block.getWorld() : null;
+        }
+
+        private boolean isWorldEnabled(World world) {
+                return world != null && worlds.contains(world.getName());
+        }
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/explosioncancel/CreeperExplosionCancelListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/explosioncancel/CreeperExplosionCancelListener.java
@@ -1,5 +1,6 @@
 package me.lele.worldSafe.listener.entities.explosioncancel;
 
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
@@ -23,13 +24,21 @@ public class CreeperExplosionCancelListener implements Listener {
 		// 检查是否是Creeper的爆炸
 		if (event.getEntityType() == EntityType.CREEPER) {
 			// 获取事件触发的世界
-			World world = event.getLocation().getWorld();
-			// 判断是否属于生效的世界
-			if (worlds.contains(world.getName())) {
-				// 阻止事件
-				event.setCancelled(true);
-			}
-		}
-	}
+                        World world = getWorld(event.getLocation());
+                        if (!isWorldEnabled(world)) {
+                                return;
+                        }
+                        // 阻止事件
+                        event.setCancelled(true);
+                }
+        }
+
+        private World getWorld(Location location) {
+                return location != null ? location.getWorld() : null;
+        }
+
+        private boolean isWorldEnabled(World world) {
+                return world != null && worlds.contains(world.getName());
+        }
 
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/explosioncancel/EndCrystalExplosionCancelListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/explosioncancel/EndCrystalExplosionCancelListener.java
@@ -1,5 +1,8 @@
 package me.lele.worldSafe.listener.entities.explosioncancel;
 
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -18,13 +21,26 @@ public class EndCrystalExplosionCancelListener implements Listener {
     @EventHandler
     public void onEntityExplode(EntityExplodeEvent event) {
         // 检查爆炸实体是否是末地水晶
-        if (event.getEntity().getType() == EntityType.END_CRYSTAL) {
-            // 判断是否启用这个世界
-            if (!worlds.contains(event.getLocation().getWorld().getName()))
+        if (isEndCrystal(event.getEntity())) {
+            World world = getWorld(event.getLocation());
+            if (!isWorldEnabled(world)) {
                 return;
+            }
             // 清空爆炸影响的方块
             event.setCancelled(true);
         }
+    }
+
+    private boolean isEndCrystal(Entity entity) {
+        return entity != null && entity.getType() == EntityType.END_CRYSTAL;
+    }
+
+    private World getWorld(Location location) {
+        return location != null ? location.getWorld() : null;
+    }
+
+    private boolean isWorldEnabled(World world) {
+        return world != null && worlds.contains(world.getName());
     }
 
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/explosioncancel/GhastExplosionCancelListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/explosioncancel/GhastExplosionCancelListener.java
@@ -1,5 +1,6 @@
 package me.lele.worldSafe.listener.entities.explosioncancel;
 
+import org.bukkit.World;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Fireball;
 import org.bukkit.entity.Ghast;
@@ -22,30 +23,38 @@ public class GhastExplosionCancelListener implements Listener {
 		// 检测实体是否为火球
 		if (e.getEntityType() != EntityType.FIREBALL)
 			return;
-		Fireball ent = (Fireball) e.getEntity();
-		// 检测此世界是否启用
-		if (!worlds.contains(ent.getWorld().getName()))
-			return;
-		// 检测是否为恶魂发出的火球
-		if (!(ent.getShooter() instanceof Ghast))
-			return;
-		// 清空受影响的方块
-		e.setCancelled(true);
-	}
+                Fireball ent = (Fireball) e.getEntity();
+                World world = getWorld(ent);
+                if (!isWorldEnabled(world))
+                        return;
+                // 检测是否为恶魂发出的火球
+                if (!(ent.getShooter() instanceof Ghast))
+                        return;
+                // 清空受影响的方块
+                e.setCancelled(true);
+        }
 
 	@EventHandler
 	void onEntityDamageByEntity(EntityDamageByEntityEvent e) {
 		// 检测造成伤害的实体是否为火球
 		if (e.getDamager().getType() != EntityType.FIREBALL)
 			return;
-		Fireball ent = (Fireball) e.getDamager();
-		// 检测此世界是否启用
-		if (!worlds.contains(ent.getWorld().getName()))
-			return;
-		// 检测是否为恶魂发出的火球
-		if (!(ent.getShooter() instanceof Ghast))
-			return;
-		//消除火球伤害
-		e.setCancelled(true);
-	}
+                Fireball ent = (Fireball) e.getDamager();
+                World world = getWorld(ent);
+                if (!isWorldEnabled(world))
+                        return;
+                // 检测是否为恶魂发出的火球
+                if (!(ent.getShooter() instanceof Ghast))
+                        return;
+                //消除火球伤害
+                e.setCancelled(true);
+        }
+
+        private World getWorld(Fireball fireball) {
+                return fireball != null ? fireball.getWorld() : null;
+        }
+
+        private boolean isWorldEnabled(World world) {
+                return world != null && worlds.contains(world.getName());
+        }
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/explosioncancel/WitherExplosionCancelListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/explosioncancel/WitherExplosionCancelListener.java
@@ -2,6 +2,7 @@ package me.lele.worldSafe.listener.entities.explosioncancel;
 
 import java.util.List;
 
+import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
@@ -20,11 +21,19 @@ public class WitherExplosionCancelListener implements Listener {
 		// 检测是否为凋零/凋零头颅
 		if (e.getEntityType() != EntityType.WITHER && e.getEntityType() != EntityType.WITHER_SKULL)
 			return;
-		Entity ent = e.getEntity();
-		// 检测是否启用这个世界
-		if (!worlds.contains(ent.getWorld().getName()))
-			return;
-		// 取消事件 阻止爆炸
-		e.setCancelled(true);
-	}
+                Entity ent = e.getEntity();
+                World world = getWorld(ent);
+                if (!isWorldEnabled(world))
+                        return;
+                // 取消事件 阻止爆炸
+                e.setCancelled(true);
+        }
+
+        private World getWorld(Entity entity) {
+                return entity != null ? entity.getWorld() : null;
+        }
+
+        private boolean isWorldEnabled(World world) {
+                return world != null && worlds.contains(world.getName());
+        }
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/explosionprevention/CreeperExplosionProtectionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/explosionprevention/CreeperExplosionProtectionListener.java
@@ -1,5 +1,6 @@
 package me.lele.worldSafe.listener.entities.explosionprevention;
 
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
@@ -19,17 +20,24 @@ public class CreeperExplosionProtectionListener implements Listener {
 	}
 
 	@EventHandler
-	public void onCreeperExplode(EntityExplodeEvent event) {
-		// 检查是否是Creeper的爆炸
-		if (event.getEntityType() == EntityType.CREEPER) {
-			// 获取事件触发的世界
-			World world = event.getLocation().getWorld();
-			// 判断是否属于生效的世界
-			if (worlds.contains(world.getName())) {
-				// 阻止事件
-				event.blockList().clear();
-			}
-		}
-	}
+        public void onCreeperExplode(EntityExplodeEvent event) {
+                // 检查是否是Creeper的爆炸
+                if (event.getEntityType() == EntityType.CREEPER) {
+                        World world = getWorld(event.getLocation());
+                        if (!isWorldEnabled(world)) {
+                                return;
+                        }
+                        // 阻止事件
+                        event.blockList().clear();
+                }
+        }
+
+        private World getWorld(Location location) {
+                return location != null ? location.getWorld() : null;
+        }
+
+        private boolean isWorldEnabled(World world) {
+                return world != null && worlds.contains(world.getName());
+        }
 
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/explosionprevention/EndCrystalExplosionPreventionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/explosionprevention/EndCrystalExplosionPreventionListener.java
@@ -1,5 +1,8 @@
 package me.lele.worldSafe.listener.entities.explosionprevention;
 
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -18,13 +21,26 @@ public class EndCrystalExplosionPreventionListener implements Listener {
     @EventHandler
     public void onEntityExplode(EntityExplodeEvent event) {
         // 检查爆炸实体是否是末地水晶
-        if (event.getEntity().getType() == EntityType.END_CRYSTAL) {
-            // 判断是否启用这个世界
-            if (!worlds.contains(event.getLocation().getWorld().getName()))
+        if (isEndCrystal(event.getEntity())) {
+            World world = getWorld(event.getLocation());
+            if (!isWorldEnabled(world)) {
                 return;
+            }
             // 清空爆炸影响的方块
             event.blockList().clear();
         }
+    }
+
+    private boolean isEndCrystal(Entity entity) {
+        return entity != null && entity.getType() == EntityType.END_CRYSTAL;
+    }
+
+    private World getWorld(Location location) {
+        return location != null ? location.getWorld() : null;
+    }
+
+    private boolean isWorldEnabled(World world) {
+        return world != null && worlds.contains(world.getName());
     }
 
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/explosionprevention/GhastExplosionProtectionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/explosionprevention/GhastExplosionProtectionListener.java
@@ -2,6 +2,7 @@ package me.lele.worldSafe.listener.entities.explosionprevention;
 
 import java.util.List;
 
+import org.bukkit.World;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Fireball;
 import org.bukkit.entity.Ghast;
@@ -21,14 +22,22 @@ public class GhastExplosionProtectionListener implements Listener {
 		// 检测实体是否为火球
 		if (e.getEntityType() != EntityType.FIREBALL)
 			return;
-		Fireball ent = (Fireball) e.getEntity();
-		// 检测此世界是否启用
-		if (!worlds.contains(ent.getWorld().getName()))
-			return;
-		// 检测是否为恶魂发出的火球
-		if (!(ent.getShooter() instanceof Ghast))
-			return;
-		// 清空受影响的方块
-		e.blockList().clear();
-	}
+                Fireball ent = (Fireball) e.getEntity();
+                World world = getWorld(ent);
+                if (!isWorldEnabled(world))
+                        return;
+                // 检测是否为恶魂发出的火球
+                if (!(ent.getShooter() instanceof Ghast))
+                        return;
+                // 清空受影响的方块
+                e.blockList().clear();
+        }
+
+        private World getWorld(Fireball fireball) {
+                return fireball != null ? fireball.getWorld() : null;
+        }
+
+        private boolean isWorldEnabled(World world) {
+                return world != null && worlds.contains(world.getName());
+        }
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/explosionprevention/WitherExplosionProtectionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/explosionprevention/WitherExplosionProtectionListener.java
@@ -3,6 +3,8 @@ package me.lele.worldSafe.listener.entities.explosionprevention;
 import java.util.List;
 
 import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
@@ -21,17 +23,33 @@ public class WitherExplosionProtectionListener implements Listener {
 		// 判断是否为凋零/凋零头
 		if (e.getEntityType() != EntityType.WITHER && e.getEntityType() != EntityType.WITHER_SKULL)
 			return;
-		Entity ent = e.getEntity();
-		// 判断方块和凋零/凋零头是否在同一世界
-		if (!e.getBlock().getWorld().equals(ent.getWorld()))
-			return;
-		// 判断是否启用该世界
-		if (!worlds.contains(ent.getWorld().getName()))
-			return;
-		// 判断是否破坏方块
-		if (e.getTo() != Material.AIR)
-			return;
-		// 取消事件
-		e.setCancelled(true);
-	}
+                Entity ent = e.getEntity();
+                World entityWorld = getWorld(ent);
+                if (!isWorldEnabled(entityWorld))
+                        return;
+                World blockWorld = getWorld(e.getBlock());
+                if (!isSameWorld(entityWorld, blockWorld))
+                        return;
+                // 判断是否破坏方块
+                if (e.getTo() != Material.AIR)
+                        return;
+                // 取消事件
+                e.setCancelled(true);
+        }
+
+        private World getWorld(Entity entity) {
+                return entity != null ? entity.getWorld() : null;
+        }
+
+        private World getWorld(Block block) {
+                return block != null ? block.getWorld() : null;
+        }
+
+        private boolean isSameWorld(World first, World second) {
+                return first != null && first.equals(second);
+        }
+
+        private boolean isWorldEnabled(World world) {
+                return world != null && worlds.contains(world.getName());
+        }
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/other/EnderDragonBlockDestructionProtectionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/other/EnderDragonBlockDestructionProtectionListener.java
@@ -3,6 +3,8 @@ package me.lele.worldSafe.listener.entities.other;
 import java.util.List;
 
 import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
@@ -21,17 +23,33 @@ public class EnderDragonBlockDestructionProtectionListener implements Listener {
 		// 判断是否为末影龙
 		if (e.getEntityType() != EntityType.ENDER_DRAGON)
 			return;
-		Entity ed = e.getEntity();
-		// 判断方块和末影龙是否在同一世界
-		if (!e.getBlock().getWorld().equals(ed.getWorld()))
-			return;
-		// 判断是否启用该世界
-		if (!worlds.contains(ed.getWorld().getName()))
-			return;
-		// 判断是否破坏方块
-		if (e.getTo() != Material.AIR)
-			return;
-		// 取消事件
-		e.setCancelled(true);
-	}
+                Entity ed = e.getEntity();
+                World dragonWorld = getWorld(ed);
+                if (!isWorldEnabled(dragonWorld))
+                        return;
+                World blockWorld = getWorld(e.getBlock());
+                if (!isSameWorld(dragonWorld, blockWorld))
+                        return;
+                // 判断是否破坏方块
+                if (e.getTo() != Material.AIR)
+                        return;
+                // 取消事件
+                e.setCancelled(true);
+        }
+
+        private World getWorld(Entity entity) {
+                return entity != null ? entity.getWorld() : null;
+        }
+
+        private World getWorld(Block block) {
+                return block != null ? block.getWorld() : null;
+        }
+
+        private boolean isSameWorld(World first, World second) {
+                return first != null && first.equals(second);
+        }
+
+        private boolean isWorldEnabled(World world) {
+                return world != null && worlds.contains(world.getName());
+        }
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/other/EnderManBlockPickupProtectionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/other/EnderManBlockPickupProtectionListener.java
@@ -1,6 +1,7 @@
 package me.lele.worldSafe.listener.entities.other;
 
 import org.bukkit.World;
+import org.bukkit.block.Block;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -23,16 +24,24 @@ public class EnderManBlockPickupProtectionListener implements Listener {
 		// 检查是否是末影人
 		if (event.getEntityType() == EntityType.ENDERMAN) {
 			// 获取事件触发的世界
-			World world = event.getBlock().getWorld();
+                        Block block = event.getBlock();
+                        World world = getWorld(block);
+                        if (!isWorldEnabled(world)) {
+                                return;
+                        }
+                        // 阻止事件
+                        event.setCancelled(true);
 
-			// 判断是否属于生效的世界
-			if (worlds.contains(world.getName())) {
-				// 阻止事件
-				event.setCancelled(true);
-			}
+                }
 
-		}
+        }
 
-	}
+        private World getWorld(Block block) {
+                return block != null ? block.getWorld() : null;
+        }
+
+        private boolean isWorldEnabled(World world) {
+                return world != null && worlds.contains(world.getName());
+        }
 
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/other/PhantomDamagePreventionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/other/PhantomDamagePreventionListener.java
@@ -1,5 +1,7 @@
 package me.lele.worldSafe.listener.entities.other;
 
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -20,13 +22,27 @@ public class PhantomDamagePreventionListener implements Listener {
     @EventHandler
     void onEntityDamageByEntity(EntityDamageByEntityEvent e) {
         // 检测造成伤害的实体是否为幻翼
-        if (e.getDamager().getType() != EntityType.PHANTOM)
+        Entity damager = e.getDamager();
+        if (!isPhantom(damager))
             return;
         // 检测此世界是否启用
-        if (!worlds.contains(e.getDamager().getWorld().getName()))
+        World world = getWorld(damager);
+        if (!isWorldEnabled(world))
             return;
         //消除幻翼伤害
         e.setCancelled(true);
+    }
+
+    private boolean isPhantom(Entity entity) {
+        return entity != null && entity.getType() == EntityType.PHANTOM;
+    }
+
+    private World getWorld(Entity entity) {
+        return entity != null ? entity.getWorld() : null;
+    }
+
+    private boolean isWorldEnabled(World world) {
+        return world != null && worlds.contains(world.getName());
     }
 
 }


### PR DESCRIPTION
## Summary
- add defensive world extraction helpers in explosion, block, and entity listeners to avoid null dereferences
- consolidate repeated world validation logic into private utility methods across listeners
- ensure farmland trampling and entity-triggered events bail out when the world cannot be resolved

## Testing
- mvn -q -DskipTests package *(fails: unable to resolve Maven plugin due to 403 from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68fa1e01db608330a3fda26e324ba9f3