### PR TITLE
Restore collection-based world listener constructors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,14 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.6.0</version>
                 <executions>
@@ -109,6 +117,27 @@
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
             <version>3.1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/src/main/java/me/lele/worldSafe/WorldSafe.java
+++ b/src/main/java/me/lele/worldSafe/WorldSafe.java
@@ -32,6 +32,7 @@ import org.spongepowered.configurate.serialize.SerializationException;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
 
@@ -135,9 +136,9 @@ public final class WorldSafe extends JavaPlugin {
                 }
         }
 
-        private void registerListener(String configNode, Function<List<String>, ? extends Listener> factory)
+        private void registerListener(String configNode, Function<Collection<String>, ? extends Listener> factory)
                         throws SerializationException {
-                List<String> worlds = configManager.getConfig().node(configNode).getList(String.class);
+                Collection<String> worlds = configManager.getConfig().node(configNode).getList(String.class);
                 if (worlds == null || worlds.isEmpty()) {
                         return;
                 }

--- a/src/main/java/me/lele/worldSafe/listener/AbstractWorldLimitedListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/AbstractWorldLimitedListener.java
@@ -1,0 +1,56 @@
+package me.lele.worldSafe.listener;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Listener;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Shared base class for listeners that only apply to specific worlds. It centralises null handling
+ * and prevents code duplication when checking whether a world is enabled.
+ */
+public abstract class AbstractWorldLimitedListener implements Listener {
+
+    private final Set<String> worlds;
+
+    protected AbstractWorldLimitedListener(Collection<String> worlds) {
+        if (worlds == null || worlds.isEmpty()) {
+            this.worlds = Collections.emptySet();
+        } else {
+            this.worlds = Collections.unmodifiableSet(new HashSet<>(worlds));
+        }
+    }
+
+    protected final boolean isWorldEnabled(String worldName) {
+        if (worldName == null) {
+            return false;
+        }
+        return worlds.contains(worldName);
+    }
+
+    protected final boolean isWorldEnabled(World world) {
+        if (world == null) {
+            return false;
+        }
+        return isWorldEnabled(world.getName());
+    }
+
+    protected final boolean isWorldEnabled(Location location) {
+        if (location == null) {
+            return false;
+        }
+        return isWorldEnabled(location.getWorld());
+    }
+
+    protected final boolean isWorldEnabled(Entity entity) {
+        if (entity == null) {
+            return false;
+        }
+        return isWorldEnabled(entity.getWorld());
+    }
+}

--- a/src/main/java/me/lele/worldSafe/listener/blocks/explosioncancel/BedExplosionCancelListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/blocks/explosioncancel/BedExplosionCancelListener.java
@@ -4,19 +4,18 @@ import org.bukkit.World;
 import org.bukkit.World.Environment;
 import org.bukkit.block.data.type.Bed;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 
-import java.util.List;
+import java.util.Collection;
 
-public class BedExplosionCancelListener implements Listener {
+import me.lele.worldSafe.listener.AbstractWorldLimitedListener;
 
-	private final List<String> worlds;
+public class BedExplosionCancelListener extends AbstractWorldLimitedListener {
 
-	public BedExplosionCancelListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
+        public BedExplosionCancelListener(Collection<String> worlds) {
+                super(worlds);
+        }
 
 	@EventHandler
 	void onPlayerInteractEvent(PlayerInteractEvent e) {
@@ -30,15 +29,15 @@ public class BedExplosionCancelListener implements Listener {
 		// 判断是否在主世界触发
 		if (w.getEnvironment() == Environment.NORMAL)
 			return;
-		// 检查玩家点击的是否为床
-		if (!(e.getClickedBlock().getBlockData() instanceof Bed))
-			return;
-		// 判断是否启用这个世界
-		if (!worlds.contains(w.getName()))
-			return;
-		// 取消事件，防止爆炸
-		e.setCancelled(true);
+                // 检查玩家点击的是否为床
+                if (!(e.getClickedBlock().getBlockData() instanceof Bed))
+                        return;
+                // 判断是否启用这个世界
+                if (!isWorldEnabled(w))
+                        return;
+                // 取消事件，防止爆炸
+                e.setCancelled(true);
 
-	}
+        }
 
 }

--- a/src/main/java/me/lele/worldSafe/listener/blocks/explosioncancel/RespawnAnchorExplosionCancelListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/blocks/explosioncancel/RespawnAnchorExplosionCancelListener.java
@@ -2,17 +2,16 @@ package me.lele.worldSafe.listener.blocks.explosioncancel;
 
 import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockExplodeEvent;
 
-import java.util.List;
+import java.util.Collection;
 
-public class RespawnAnchorExplosionCancelListener implements Listener {
+import me.lele.worldSafe.listener.AbstractWorldLimitedListener;
 
-    private final List<String> worlds;
+public class RespawnAnchorExplosionCancelListener extends AbstractWorldLimitedListener {
 
-    public RespawnAnchorExplosionCancelListener(List<String> worlds) {
-        this.worlds = worlds;
+    public RespawnAnchorExplosionCancelListener(Collection<String> worlds) {
+        super(worlds);
     }
 
     @EventHandler
@@ -21,7 +20,7 @@ public class RespawnAnchorExplosionCancelListener implements Listener {
         // 检测是否为 重生锚 爆炸
         if (e.getExplodedBlockState().getBlockData().getMaterial() == Material.RESPAWN_ANCHOR) {
             // 判断是否启用这个世界
-            if (!worlds.contains(e.getExplodedBlockState().getLocation().getWorld().getName()))
+            if (!isWorldEnabled(e.getExplodedBlockState().getLocation()))
                 return;
             // 清空爆炸影响的方块
             e.setCancelled(true);

--- a/src/main/java/me/lele/worldSafe/listener/blocks/explosioncancel/TNTExplosionCancelListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/blocks/explosioncancel/TNTExplosionCancelListener.java
@@ -3,28 +3,28 @@ package me.lele.worldSafe.listener.blocks.explosioncancel;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityExplodeEvent;
 
-import java.util.List;
+import java.util.Collection;
 
-public class TNTExplosionCancelListener implements Listener {
-	private final List<String> worlds;
+import me.lele.worldSafe.listener.AbstractWorldLimitedListener;
 
-	public TNTExplosionCancelListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
+public class TNTExplosionCancelListener extends AbstractWorldLimitedListener {
 
-	@EventHandler
-	void onTNTExplode(EntityExplodeEvent e) {
-		// 检测是否为TNT类实体
-		if (e.getEntityType() != EntityType.TNT && e.getEntityType() != EntityType.TNT_MINECART)
-			return;
-		Entity ent = e.getEntity();
-		// 判断是否启用这个世界
-		if (!worlds.contains(ent.getWorld().getName()))
-			return;
-		// 清空爆炸影响的方块
-		e.setCancelled(true);
-	}
+        public TNTExplosionCancelListener(Collection<String> worlds) {
+                super(worlds);
+        }
+
+        @EventHandler
+        void onTNTExplode(EntityExplodeEvent e) {
+                // 检测是否为TNT类实体
+                if (e.getEntityType() != EntityType.TNT && e.getEntityType() != EntityType.TNT_MINECART)
+                        return;
+                Entity ent = e.getEntity();
+                // 判断是否启用这个世界
+                if (!isWorldEnabled(ent))
+                        return;
+                // 清空爆炸影响的方块
+                e.setCancelled(true);
+        }
 }

--- a/src/main/java/me/lele/worldSafe/listener/blocks/explosionprevention/BedExplosionProtectionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/blocks/explosionprevention/BedExplosionProtectionListener.java
@@ -2,17 +2,16 @@ package me.lele.worldSafe.listener.blocks.explosionprevention;
 
 import org.bukkit.block.data.type.Bed;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockExplodeEvent;
 
-import java.util.List;
+import java.util.Collection;
 
-public class BedExplosionProtectionListener implements Listener {
+import me.lele.worldSafe.listener.AbstractWorldLimitedListener;
 
-    private final List<String> worlds;
+public class BedExplosionProtectionListener extends AbstractWorldLimitedListener {
 
-    public BedExplosionProtectionListener(List<String> worlds) {
-        this.worlds = worlds;
+    public BedExplosionProtectionListener(Collection<String> worlds) {
+        super(worlds);
     }
 
     @EventHandler
@@ -21,7 +20,7 @@ public class BedExplosionProtectionListener implements Listener {
         // 检测是否为 床 爆炸
         if (e.getExplodedBlockState().getBlockData() instanceof Bed){
             // 判断是否启用这个世界
-            if (!worlds.contains(e.getExplodedBlockState().getLocation().getWorld().getName()))
+            if (!isWorldEnabled(e.getExplodedBlockState().getLocation()))
                 return;
             // 清空爆炸影响的方块
             e.blockList().clear();

--- a/src/main/java/me/lele/worldSafe/listener/blocks/explosionprevention/RespawnAnchorExplosionPreventionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/blocks/explosionprevention/RespawnAnchorExplosionPreventionListener.java
@@ -2,17 +2,16 @@ package me.lele.worldSafe.listener.blocks.explosionprevention;
 
 import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockExplodeEvent;
 
-import java.util.List;
+import java.util.Collection;
 
-public class RespawnAnchorExplosionPreventionListener implements Listener {
+import me.lele.worldSafe.listener.AbstractWorldLimitedListener;
 
-    private final List<String> worlds;
+public class RespawnAnchorExplosionPreventionListener extends AbstractWorldLimitedListener {
 
-    public RespawnAnchorExplosionPreventionListener(List<String> worlds) {
-        this.worlds = worlds;
+    public RespawnAnchorExplosionPreventionListener(Collection<String> worlds) {
+        super(worlds);
     }
 
     @EventHandler
@@ -21,7 +20,7 @@ public class RespawnAnchorExplosionPreventionListener implements Listener {
         // 检测是否为 重生锚 爆炸
         if (e.getExplodedBlockState().getBlockData().getMaterial() == Material.RESPAWN_ANCHOR) {
             // 判断是否启用这个世界
-            if (!worlds.contains(e.getExplodedBlockState().getLocation().getWorld().getName()))
+            if (!isWorldEnabled(e.getExplodedBlockState().getLocation()))
                 return;
             // 清空爆炸影响的方块
             e.blockList().clear();

--- a/src/main/java/me/lele/worldSafe/listener/blocks/explosionprevention/TNTExplosionProtectionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/blocks/explosionprevention/TNTExplosionProtectionListener.java
@@ -1,30 +1,30 @@
 package me.lele.worldSafe.listener.blocks.explosionprevention;
 
-import java.util.List;
+import java.util.Collection;
 
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityExplodeEvent;
 
-public class TNTExplosionProtectionListener implements Listener {
-	private final List<String> worlds;
+import me.lele.worldSafe.listener.AbstractWorldLimitedListener;
 
-	public TNTExplosionProtectionListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
+public class TNTExplosionProtectionListener extends AbstractWorldLimitedListener {
 
-	@EventHandler
-	void onTNTExplode(EntityExplodeEvent e) {
-		// 检测是否为TNT类实体
-		if (e.getEntityType() != EntityType.TNT && e.getEntityType() != EntityType.TNT_MINECART)
-			return;
-		Entity ent = e.getEntity();
-		// 判断是否启用这个世界
-		if (!worlds.contains(ent.getWorld().getName()))
-			return;
-		// 清空爆炸影响的方块
-		e.blockList().clear();
-	}
+        public TNTExplosionProtectionListener(Collection<String> worlds) {
+                super(worlds);
+        }
+
+        @EventHandler
+        void onTNTExplode(EntityExplodeEvent e) {
+                // 检测是否为TNT类实体
+                if (e.getEntityType() != EntityType.TNT && e.getEntityType() != EntityType.TNT_MINECART)
+                        return;
+                Entity ent = e.getEntity();
+                // 判断是否启用这个世界
+                if (!isWorldEnabled(ent))
+                        return;
+                // 清空爆炸影响的方块
+                e.blockList().clear();
+        }
 }

--- a/src/main/java/me/lele/worldSafe/listener/blocks/other/CropTrampleProtectionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/blocks/other/CropTrampleProtectionListener.java
@@ -1,33 +1,33 @@
 package me.lele.worldSafe.listener.blocks.other;
 
-import java.util.List;
+import java.util.Collection;
 
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 
-public class CropTrampleProtectionListener implements Listener {
-	private final List<String> worlds;
+import me.lele.worldSafe.listener.AbstractWorldLimitedListener;
 
-	public CropTrampleProtectionListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
+public class CropTrampleProtectionListener extends AbstractWorldLimitedListener {
 
-	@EventHandler
-	void onBlockChangeByEntity(EntityChangeBlockEvent e) {
-		Block b = e.getBlock();
-		// 判断是否为耕地
-		if (b.getType() != Material.FARMLAND)
-			return;
-		// 检测是否为踩踏
-		if (e.getTo() != Material.DIRT && e.getTo() != Material.GRASS_BLOCK)
-			return;
-		// 检测世界是否启用
-		if (!worlds.contains(b.getLocation().getWorld().getName()))
-			return;
-		// 取消事件
-		e.setCancelled(true);
-	}
+        public CropTrampleProtectionListener(Collection<String> worlds) {
+                super(worlds);
+        }
+
+        @EventHandler
+        void onBlockChangeByEntity(EntityChangeBlockEvent e) {
+                Block b = e.getBlock();
+                // 判断是否为耕地
+                if (b.getType() != Material.FARMLAND)
+                        return;
+                // 检测是否为踩踏
+                if (e.getTo() != Material.DIRT && e.getTo() != Material.GRASS_BLOCK)
+                        return;
+                // 检测世界是否启用
+                if (!isWorldEnabled(b.getLocation()))
+                        return;
+                // 取消事件
+                e.setCancelled(true);
+        }
 }

--- a/src/main/java/me/lele/worldSafe/listener/blocks/other/DragonEggTeleportationPreventionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/blocks/other/DragonEggTeleportationPreventionListener.java
@@ -1,30 +1,30 @@
 package me.lele.worldSafe.listener.blocks.other;
 
-import java.util.List;
+import java.util.Collection;
 
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockFromToEvent;
 
-public class DragonEggTeleportationPreventionListener implements Listener {
-	private final List<String> worlds;
+import me.lele.worldSafe.listener.AbstractWorldLimitedListener;
 
-	public DragonEggTeleportationPreventionListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
+public class DragonEggTeleportationPreventionListener extends AbstractWorldLimitedListener {
 
-	@EventHandler
-	void onDragonEggTeleport(BlockFromToEvent e) {
-		Block b = e.getBlock();
-		// 检测方块是否为龙蛋
-		if (b.getType() != Material.DRAGON_EGG)
-			return;
-		// 判断是否启动这个世界
-		if (!worlds.contains(b.getWorld().getName()))
-			return;
-		// 取消事件 即禁止龙蛋瞬移
-		e.setCancelled(true);
-	}
+        public DragonEggTeleportationPreventionListener(Collection<String> worlds) {
+                super(worlds);
+        }
+
+        @EventHandler
+        void onDragonEggTeleport(BlockFromToEvent e) {
+                Block b = e.getBlock();
+                // 检测方块是否为龙蛋
+                if (b.getType() != Material.DRAGON_EGG)
+                        return;
+                // 判断是否启动这个世界
+                if (!isWorldEnabled(b.getWorld()))
+                        return;
+                // 取消事件 即禁止龙蛋瞬移
+                e.setCancelled(true);
+        }
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/explosioncancel/CreeperExplosionCancelListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/explosioncancel/CreeperExplosionCancelListener.java
@@ -1,35 +1,29 @@
 package me.lele.worldSafe.listener.entities.explosioncancel;
 
-import org.bukkit.World;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityExplodeEvent;
 
-import java.util.List;
+import java.util.Collection;
 
-public class CreeperExplosionCancelListener implements Listener {
+import me.lele.worldSafe.listener.AbstractWorldLimitedListener;
 
-	// 定义生效的世界
-	private final List<String> worlds;
+public class CreeperExplosionCancelListener extends AbstractWorldLimitedListener {
 
-	// 把配置文件中的生效世界赋值到worlds
-	public CreeperExplosionCancelListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
+        public CreeperExplosionCancelListener(Collection<String> worlds) {
+                super(worlds);
+        }
 
-	@EventHandler
-	public void onCreeperExplode(EntityExplodeEvent event) {
-		// 检查是否是Creeper的爆炸
-		if (event.getEntityType() == EntityType.CREEPER) {
-			// 获取事件触发的世界
-			World world = event.getLocation().getWorld();
-			// 判断是否属于生效的世界
-			if (worlds.contains(world.getName())) {
-				// 阻止事件
-				event.setCancelled(true);
-			}
-		}
-	}
+        @EventHandler
+        public void onCreeperExplode(EntityExplodeEvent event) {
+                // 检查是否是Creeper的爆炸
+                if (event.getEntityType() == EntityType.CREEPER) {
+                        // 判断是否属于生效的世界
+                        if (isWorldEnabled(event.getLocation())) {
+                                // 阻止事件
+                                event.setCancelled(true);
+                        }
+                }
+        }
 
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/explosioncancel/EndCrystalExplosionCancelListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/explosioncancel/EndCrystalExplosionCancelListener.java
@@ -2,17 +2,16 @@ package me.lele.worldSafe.listener.entities.explosioncancel;
 
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityExplodeEvent;
 
-import java.util.List;
+import java.util.Collection;
 
-public class EndCrystalExplosionCancelListener implements Listener {
+import me.lele.worldSafe.listener.AbstractWorldLimitedListener;
 
-    private final List<String> worlds;
+public class EndCrystalExplosionCancelListener extends AbstractWorldLimitedListener {
 
-    public EndCrystalExplosionCancelListener(List<String> worlds) {
-        this.worlds = worlds;
+    public EndCrystalExplosionCancelListener(Collection<String> worlds) {
+        super(worlds);
     }
 
     @EventHandler
@@ -20,7 +19,7 @@ public class EndCrystalExplosionCancelListener implements Listener {
         // 检查爆炸实体是否是末地水晶
         if (event.getEntity().getType() == EntityType.END_CRYSTAL) {
             // 判断是否启用这个世界
-            if (!worlds.contains(event.getLocation().getWorld().getName()))
+            if (!isWorldEnabled(event.getLocation()))
                 return;
             // 清空爆炸影响的方块
             event.setCancelled(true);

--- a/src/main/java/me/lele/worldSafe/listener/entities/explosioncancel/GhastExplosionCancelListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/explosioncancel/GhastExplosionCancelListener.java
@@ -4,48 +4,48 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Fireball;
 import org.bukkit.entity.Ghast;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 
-import java.util.List;
+import java.util.Collection;
 
-public class GhastExplosionCancelListener implements Listener {
-	private final List<String> worlds;
+import me.lele.worldSafe.listener.AbstractWorldLimitedListener;
 
-	public GhastExplosionCancelListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
+public class GhastExplosionCancelListener extends AbstractWorldLimitedListener {
 
-	@EventHandler
-	void onFileballExplode(EntityExplodeEvent e) {
-		// 检测实体是否为火球
-		if (e.getEntityType() != EntityType.FIREBALL)
-			return;
-		Fireball ent = (Fireball) e.getEntity();
-		// 检测此世界是否启用
-		if (!worlds.contains(ent.getWorld().getName()))
-			return;
-		// 检测是否为恶魂发出的火球
-		if (!(ent.getShooter() instanceof Ghast))
-			return;
-		// 清空受影响的方块
+        public GhastExplosionCancelListener(Collection<String> worlds) {
+                super(worlds);
+        }
+
+        @EventHandler
+        void onFileballExplode(EntityExplodeEvent e) {
+                // 检测实体是否为火球
+                if (e.getEntityType() != EntityType.FIREBALL)
+                        return;
+                Fireball ent = (Fireball) e.getEntity();
+                // 检测此世界是否启用
+                if (!isWorldEnabled(ent))
+                        return;
+                // 检测是否为恶魂发出的火球
+                if (!(ent.getShooter() instanceof Ghast))
+                        return;
+                // 清空受影响的方块
 		e.setCancelled(true);
 	}
 
 	@EventHandler
 	void onEntityDamageByEntity(EntityDamageByEntityEvent e) {
-		// 检测造成伤害的实体是否为火球
-		if (e.getDamager().getType() != EntityType.FIREBALL)
-			return;
-		Fireball ent = (Fireball) e.getDamager();
-		// 检测此世界是否启用
-		if (!worlds.contains(ent.getWorld().getName()))
-			return;
-		// 检测是否为恶魂发出的火球
-		if (!(ent.getShooter() instanceof Ghast))
-			return;
-		//消除火球伤害
+                // 检测造成伤害的实体是否为火球
+                if (e.getDamager().getType() != EntityType.FIREBALL)
+                        return;
+                Fireball ent = (Fireball) e.getDamager();
+                // 检测此世界是否启用
+                if (!isWorldEnabled(ent))
+                        return;
+                // 检测是否为恶魂发出的火球
+                if (!(ent.getShooter() instanceof Ghast))
+                        return;
+                //消除火球伤害
 		e.setCancelled(true);
 	}
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/explosioncancel/WitherExplosionCancelListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/explosioncancel/WitherExplosionCancelListener.java
@@ -1,30 +1,30 @@
 package me.lele.worldSafe.listener.entities.explosioncancel;
 
-import java.util.List;
+import java.util.Collection;
 
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityExplodeEvent;
 
-public class WitherExplosionCancelListener implements Listener {
-	private final List<String> worlds;
+import me.lele.worldSafe.listener.AbstractWorldLimitedListener;
 
-	public WitherExplosionCancelListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
+public class WitherExplosionCancelListener extends AbstractWorldLimitedListener {
 
-	@EventHandler
-	void onExplode(EntityExplodeEvent e) {
-		// 检测是否为凋零/凋零头颅
-		if (e.getEntityType() != EntityType.WITHER && e.getEntityType() != EntityType.WITHER_SKULL)
-			return;
-		Entity ent = e.getEntity();
-		// 检测是否启用这个世界
-		if (!worlds.contains(ent.getWorld().getName()))
-			return;
-		// 取消事件 阻止爆炸
-		e.setCancelled(true);
-	}
+        public WitherExplosionCancelListener(Collection<String> worlds) {
+                super(worlds);
+        }
+
+        @EventHandler
+        void onExplode(EntityExplodeEvent e) {
+                // 检测是否为凋零/凋零头颅
+                if (e.getEntityType() != EntityType.WITHER && e.getEntityType() != EntityType.WITHER_SKULL)
+                        return;
+                Entity ent = e.getEntity();
+                // 检测是否启用这个世界
+                if (!isWorldEnabled(ent))
+                        return;
+                // 取消事件 阻止爆炸
+                e.setCancelled(true);
+        }
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/explosionprevention/CreeperExplosionProtectionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/explosionprevention/CreeperExplosionProtectionListener.java
@@ -1,35 +1,29 @@
 package me.lele.worldSafe.listener.entities.explosionprevention;
 
-import org.bukkit.World;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityExplodeEvent;
 
-import java.util.List;
+import java.util.Collection;
 
-public class CreeperExplosionProtectionListener implements Listener {
+import me.lele.worldSafe.listener.AbstractWorldLimitedListener;
 
-	// 定义生效的世界
-	private final List<String> worlds;
+public class CreeperExplosionProtectionListener extends AbstractWorldLimitedListener {
 
-	// 把配置文件中的生效世界赋值到worlds
-	public CreeperExplosionProtectionListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
+        public CreeperExplosionProtectionListener(Collection<String> worlds) {
+                super(worlds);
+        }
 
-	@EventHandler
-	public void onCreeperExplode(EntityExplodeEvent event) {
-		// 检查是否是Creeper的爆炸
-		if (event.getEntityType() == EntityType.CREEPER) {
-			// 获取事件触发的世界
-			World world = event.getLocation().getWorld();
-			// 判断是否属于生效的世界
-			if (worlds.contains(world.getName())) {
-				// 阻止事件
-				event.blockList().clear();
-			}
-		}
-	}
+        @EventHandler
+        public void onCreeperExplode(EntityExplodeEvent event) {
+                // 检查是否是Creeper的爆炸
+                if (event.getEntityType() == EntityType.CREEPER) {
+                        // 判断是否属于生效的世界
+                        if (isWorldEnabled(event.getLocation())) {
+                                // 阻止事件
+                                event.blockList().clear();
+                        }
+                }
+        }
 
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/explosionprevention/EndCrystalExplosionPreventionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/explosionprevention/EndCrystalExplosionPreventionListener.java
@@ -2,17 +2,16 @@ package me.lele.worldSafe.listener.entities.explosionprevention;
 
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityExplodeEvent;
 
-import java.util.List;
+import java.util.Collection;
 
-public class EndCrystalExplosionPreventionListener implements Listener {
+import me.lele.worldSafe.listener.AbstractWorldLimitedListener;
 
-    private final List<String> worlds;
+public class EndCrystalExplosionPreventionListener extends AbstractWorldLimitedListener {
 
-    public EndCrystalExplosionPreventionListener(List<String> worlds) {
-        this.worlds = worlds;
+    public EndCrystalExplosionPreventionListener(Collection<String> worlds) {
+        super(worlds);
     }
 
     @EventHandler
@@ -20,7 +19,7 @@ public class EndCrystalExplosionPreventionListener implements Listener {
         // 检查爆炸实体是否是末地水晶
         if (event.getEntity().getType() == EntityType.END_CRYSTAL) {
             // 判断是否启用这个世界
-            if (!worlds.contains(event.getLocation().getWorld().getName()))
+            if (!isWorldEnabled(event.getLocation()))
                 return;
             // 清空爆炸影响的方块
             event.blockList().clear();

--- a/src/main/java/me/lele/worldSafe/listener/entities/explosionprevention/GhastExplosionProtectionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/explosionprevention/GhastExplosionProtectionListener.java
@@ -1,34 +1,34 @@
 package me.lele.worldSafe.listener.entities.explosionprevention;
 
-import java.util.List;
+import java.util.Collection;
 
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Fireball;
 import org.bukkit.entity.Ghast;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityExplodeEvent;
 
-public class GhastExplosionProtectionListener implements Listener {
-	private final List<String> worlds;
+import me.lele.worldSafe.listener.AbstractWorldLimitedListener;
 
-	public GhastExplosionProtectionListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
+public class GhastExplosionProtectionListener extends AbstractWorldLimitedListener {
 
-	@EventHandler
-	void onFileballExplode(EntityExplodeEvent e) {
-		// 检测实体是否为火球
-		if (e.getEntityType() != EntityType.FIREBALL)
-			return;
-		Fireball ent = (Fireball) e.getEntity();
-		// 检测此世界是否启用
-		if (!worlds.contains(ent.getWorld().getName()))
-			return;
-		// 检测是否为恶魂发出的火球
-		if (!(ent.getShooter() instanceof Ghast))
-			return;
-		// 清空受影响的方块
+        public GhastExplosionProtectionListener(Collection<String> worlds) {
+                super(worlds);
+        }
+
+        @EventHandler
+        void onFileballExplode(EntityExplodeEvent e) {
+                // 检测实体是否为火球
+                if (e.getEntityType() != EntityType.FIREBALL)
+                        return;
+                Fireball ent = (Fireball) e.getEntity();
+                // 检测此世界是否启用
+                if (!isWorldEnabled(ent))
+                        return;
+                // 检测是否为恶魂发出的火球
+                if (!(ent.getShooter() instanceof Ghast))
+                        return;
+                // 清空受影响的方块
 		e.blockList().clear();
 	}
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/explosionprevention/WitherExplosionProtectionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/explosionprevention/WitherExplosionProtectionListener.java
@@ -1,37 +1,37 @@
 package me.lele.worldSafe.listener.entities.explosionprevention;
 
-import java.util.List;
+import java.util.Collection;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 
-public class WitherExplosionProtectionListener implements Listener {
-	private final List<String> worlds;
+import me.lele.worldSafe.listener.AbstractWorldLimitedListener;
 
-	public WitherExplosionProtectionListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
+public class WitherExplosionProtectionListener extends AbstractWorldLimitedListener {
 
-	@EventHandler
-	void onWitherDestroyBlock(EntityChangeBlockEvent e) {
-		// 判断是否为凋零/凋零头
-		if (e.getEntityType() != EntityType.WITHER && e.getEntityType() != EntityType.WITHER_SKULL)
-			return;
-		Entity ent = e.getEntity();
-		// 判断方块和凋零/凋零头是否在同一世界
-		if (!e.getBlock().getWorld().equals(ent.getWorld()))
-			return;
-		// 判断是否启用该世界
-		if (!worlds.contains(ent.getWorld().getName()))
-			return;
-		// 判断是否破坏方块
-		if (e.getTo() != Material.AIR)
-			return;
-		// 取消事件
+        public WitherExplosionProtectionListener(Collection<String> worlds) {
+                super(worlds);
+        }
+
+        @EventHandler
+        void onWitherDestroyBlock(EntityChangeBlockEvent e) {
+                // 判断是否为凋零/凋零头
+                if (e.getEntityType() != EntityType.WITHER && e.getEntityType() != EntityType.WITHER_SKULL)
+                        return;
+                Entity ent = e.getEntity();
+                // 判断方块和凋零/凋零头是否在同一世界
+                if (!e.getBlock().getWorld().equals(ent.getWorld()))
+                        return;
+                // 判断是否启用该世界
+                if (!isWorldEnabled(ent))
+                        return;
+                // 判断是否破坏方块
+                if (e.getTo() != Material.AIR)
+                        return;
+                // 取消事件
 		e.setCancelled(true);
 	}
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/other/EnderDragonBlockDestructionProtectionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/other/EnderDragonBlockDestructionProtectionListener.java
@@ -1,37 +1,37 @@
 package me.lele.worldSafe.listener.entities.other;
 
-import java.util.List;
+import java.util.Collection;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 
-public class EnderDragonBlockDestructionProtectionListener implements Listener {
-	private final List<String> worlds;
+import me.lele.worldSafe.listener.AbstractWorldLimitedListener;
 
-	public EnderDragonBlockDestructionProtectionListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
+public class EnderDragonBlockDestructionProtectionListener extends AbstractWorldLimitedListener {
 
-	@EventHandler
-	void onEnderDragonDestroyBlock(EntityChangeBlockEvent e) {
-		// 判断是否为末影龙
-		if (e.getEntityType() != EntityType.ENDER_DRAGON)
-			return;
-		Entity ed = e.getEntity();
-		// 判断方块和末影龙是否在同一世界
-		if (!e.getBlock().getWorld().equals(ed.getWorld()))
-			return;
-		// 判断是否启用该世界
-		if (!worlds.contains(ed.getWorld().getName()))
-			return;
-		// 判断是否破坏方块
-		if (e.getTo() != Material.AIR)
-			return;
-		// 取消事件
+        public EnderDragonBlockDestructionProtectionListener(Collection<String> worlds) {
+                super(worlds);
+        }
+
+        @EventHandler
+        void onEnderDragonDestroyBlock(EntityChangeBlockEvent e) {
+                // 判断是否为末影龙
+                if (e.getEntityType() != EntityType.ENDER_DRAGON)
+                        return;
+                Entity ed = e.getEntity();
+                // 判断方块和末影龙是否在同一世界
+                if (!e.getBlock().getWorld().equals(ed.getWorld()))
+                        return;
+                // 判断是否启用该世界
+                if (!isWorldEnabled(ed))
+                        return;
+                // 判断是否破坏方块
+                if (e.getTo() != Material.AIR)
+                        return;
+                // 取消事件
 		e.setCancelled(true);
 	}
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/other/EnderManBlockPickupProtectionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/other/EnderManBlockPickupProtectionListener.java
@@ -1,37 +1,30 @@
 package me.lele.worldSafe.listener.entities.other;
 
-import org.bukkit.World;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 
-import java.util.List;
+import java.util.Collection;
 
-public class EnderManBlockPickupProtectionListener implements Listener {
+import me.lele.worldSafe.listener.AbstractWorldLimitedListener;
 
-	// 定义生效的世界
-	private final List<String> worlds;
+public class EnderManBlockPickupProtectionListener extends AbstractWorldLimitedListener {
 
-	// 把配置文件中的生效世界赋值到worlds
-	public EnderManBlockPickupProtectionListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
+        public EnderManBlockPickupProtectionListener(Collection<String> worlds) {
+                super(worlds);
+        }
 
-	@EventHandler
-	public void onEnderManBlockPickup(EntityChangeBlockEvent event) {
-		// 检查是否是末影人
-		if (event.getEntityType() == EntityType.ENDERMAN) {
-			// 获取事件触发的世界
-			World world = event.getBlock().getWorld();
+        @EventHandler
+        public void onEnderManBlockPickup(EntityChangeBlockEvent event) {
+                // 检查是否是末影人
+                if (event.getEntityType() == EntityType.ENDERMAN) {
+                        // 判断是否属于生效的世界
+                        if (isWorldEnabled(event.getBlock().getWorld())) {
+                                // 阻止事件
+                                event.setCancelled(true);
+                        }
 
-			// 判断是否属于生效的世界
-			if (worlds.contains(world.getName())) {
-				// 阻止事件
-				event.setCancelled(true);
-			}
-
-		}
+                }
 
 	}
 

--- a/src/main/java/me/lele/worldSafe/listener/entities/other/PhantomDamagePreventionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/other/PhantomDamagePreventionListener.java
@@ -2,19 +2,16 @@ package me.lele.worldSafe.listener.entities.other;
 
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 
-import java.util.List;
+import java.util.Collection;
 
-public class PhantomDamagePreventionListener implements Listener {
+import me.lele.worldSafe.listener.AbstractWorldLimitedListener;
 
-    // 定义生效的世界
-    private final List<String> worlds;
+public class PhantomDamagePreventionListener extends AbstractWorldLimitedListener {
 
-    // 把配置文件中的生效世界赋值到worlds
-    public PhantomDamagePreventionListener(List<String> worlds) {
-        this.worlds = worlds;
+    public PhantomDamagePreventionListener(Collection<String> worlds) {
+        super(worlds);
     }
 
     @EventHandler
@@ -23,7 +20,7 @@ public class PhantomDamagePreventionListener implements Listener {
         if (e.getDamager().getType() != EntityType.PHANTOM)
             return;
         // 检测此世界是否启用
-        if (!worlds.contains(e.getDamager().getWorld().getName()))
+        if (!isWorldEnabled(e.getDamager()))
             return;
         //消除幻翼伤害
         e.setCancelled(true);

--- a/src/test/java/me/lele/worldSafe/listener/AbstractWorldLimitedListenerTest.java
+++ b/src/test/java/me/lele/worldSafe/listener/AbstractWorldLimitedListenerTest.java
@@ -1,0 +1,83 @@
+package me.lele.worldSafe.listener;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AbstractWorldLimitedListenerTest {
+
+    private static class TestListener extends AbstractWorldLimitedListener {
+
+        protected TestListener(Collection<String> worlds) {
+            super(worlds);
+        }
+
+        boolean checkWorldName(String worldName) {
+            return isWorldEnabled(worldName);
+        }
+
+        boolean checkWorld(World world) {
+            return isWorldEnabled(world);
+        }
+
+        boolean checkLocation(Location location) {
+            return isWorldEnabled(location);
+        }
+
+        boolean checkEntity(Entity entity) {
+            return isWorldEnabled(entity);
+        }
+    }
+
+    @Test
+    void shouldRejectNullWorldCollections() {
+        TestListener listener = new TestListener(null);
+
+        assertFalse(listener.checkWorldName("world"));
+    }
+
+    @Test
+    void shouldRecogniseEnabledWorldByName() {
+        TestListener listener = new TestListener(List.of("world", "nether"));
+
+        assertTrue(listener.checkWorldName("world"));
+        assertFalse(listener.checkWorldName("end"));
+    }
+
+    @Test
+    void shouldHandleNullInputsGracefully() {
+        TestListener listener = new TestListener(List.of("world"));
+
+        assertFalse(listener.checkWorld(null));
+        assertFalse(listener.checkLocation(null));
+        assertFalse(listener.checkEntity(null));
+        assertFalse(listener.checkWorldName(null));
+    }
+
+    @Test
+    void shouldCheckWorldFromBukkitObjects() {
+        World world = mock(World.class);
+        when(world.getName()).thenReturn("world");
+
+        Location location = mock(Location.class);
+        when(location.getWorld()).thenReturn(world);
+
+        Entity entity = mock(Entity.class);
+        when(entity.getWorld()).thenReturn(world);
+
+        TestListener listener = new TestListener(List.of("world"));
+
+        assertTrue(listener.checkWorld(world));
+        assertTrue(listener.checkLocation(location));
+        assertTrue(listener.checkEntity(entity));
+    }
+}


### PR DESCRIPTION
## Summary
- revert world-limited listeners to accept `Collection<String>` inputs while keeping the shared null-safe helper
- adjust the listener registration helper to work with the restored constructor signature from configuration lists
- update the abstract listener unit test to match the constructor parameter type change

## Testing
- mvn -q test *(fails: Unable to download maven-resources-plugin because repo.maven.apache.org responded 403)*

------
https://chatgpt.com/codex/tasks/task_e_68fa1e0333848330ab8f96f8d78ce313