### PR TITLE
Refactor feature reloading to centralize listener reset

### DIFF
--- a/src/main/java/me/lele/worldSafe/WorldSafe.java
+++ b/src/main/java/me/lele/worldSafe/WorldSafe.java
@@ -33,6 +33,7 @@ import org.spongepowered.configurate.serialize.SerializationException;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
@@ -137,15 +138,6 @@ public final class WorldSafe extends JavaPlugin {
 	}
 
 
-        public void reloadFeatures() {
-                try {
-                        loadFeatures();
-                } catch (SerializationException e) {
-                        String pathInfo = e.path() != null ? e.path().toString() : "未知节点";
-                        getLogger().severe("重载配置失败，节点 " + pathInfo + " 解析失败: " + e.getMessage());
-                }
-        }
-
         private void registerListener(String configNode, Function<List<String>, ? extends Listener> factory)
                         throws SerializationException {
                 List<String> worlds = configManager.getConfig().node(configNode).getList(String.class);
@@ -157,8 +149,19 @@ public final class WorldSafe extends JavaPlugin {
                 listeners.add(listener);
         }
 
+        public void resetFeatures() {
+                HandlerList.unregisterAll(this);
+                listeners.clear();
+                try {
+                        loadFeatures();
+                } catch (SerializationException e) {
+                        String pathInfo = e.path() != null ? e.path().toString() : "未知节点";
+                        getLogger().severe("重载配置失败，节点 " + pathInfo + " 解析失败: " + e.getMessage());
+                }
+        }
+
         public List<Listener> getListeners() {
-                return listeners;
+                return Collections.unmodifiableList(listeners);
         }
 
 

--- a/src/main/java/me/lele/worldSafe/command/WorldSafeCommand.java
+++ b/src/main/java/me/lele/worldSafe/command/WorldSafeCommand.java
@@ -6,8 +6,6 @@ import dev.rollczi.litecommands.annotations.execute.Execute;
 import dev.rollczi.litecommands.annotations.permission.Permission;
 import me.lele.worldSafe.WorldSafe;
 import org.bukkit.command.CommandSender;
-import org.bukkit.event.HandlerList;
-import org.bukkit.event.Listener;
 
 import static me.lele.worldSafe.WorldSafe.configManager;
 
@@ -39,17 +37,7 @@ public class WorldSafeCommand {
             sender.sendMessage("配置重载失败，请检查控制台日志。");
             return;
         }
-        //套上线程同步锁,保证重载期间服务器停止处理,避免有生物在重载的几毫秒时间里破坏方块
-        synchronized (this) {
-            //重载监听器
-            for (Listener listener : plugin.getListeners()) {
-                HandlerList.unregisterAll(listener);
-            }
-            // 清空监听器列表
-            plugin.getListeners().clear();
-            //重新注册监听器
-            plugin.reloadFeatures();
-        }
+        plugin.resetFeatures();
 
         sender.sendMessage("配置已重载！");
     }


### PR DESCRIPTION
## Summary
- add a plugin-level resetFeatures helper that clears and reloads registered listeners safely
- simplify the reload command to rely on the new helper after a successful configuration reload
- expose the current listener list as an unmodifiable view to prevent accidental external mutation

## Testing
- `mvn -q -DskipTests package` *(fails: unable to download dependencies due to 403 from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68fa4c8892088330b4048f5969bd4cb2