### PR TITLE
Refactor world-scoped listeners

### DIFF
--- a/src/main/java/me/lele/worldSafe/listener/WorldScopedFeature.java
+++ b/src/main/java/me/lele/worldSafe/listener/WorldScopedFeature.java
@@ -1,0 +1,69 @@
+package me.lele.worldSafe.listener;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Listener;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public abstract class WorldScopedFeature implements Listener {
+
+        private final Set<String> worlds;
+
+        protected WorldScopedFeature(Collection<String> worlds) {
+                if (worlds == null || worlds.isEmpty()) {
+                        this.worlds = Set.of();
+                        return;
+                }
+                this.worlds = Collections.unmodifiableSet(worlds.stream()
+                        .filter(Objects::nonNull)
+                        .map(String::trim)
+                        .filter(name -> !name.isEmpty())
+                        .map(name -> name.toLowerCase(Locale.ROOT))
+                        .collect(Collectors.toCollection(LinkedHashSet::new)));
+        }
+
+        protected World getWorld(Location location) {
+                return location != null ? location.getWorld() : null;
+        }
+
+        protected World getWorld(Entity entity) {
+                return entity != null ? entity.getWorld() : null;
+        }
+
+        protected World getWorld(Block block) {
+                return block != null ? block.getWorld() : null;
+        }
+
+        protected boolean isWorldEnabled(Location location) {
+                return isWorldEnabled(getWorld(location));
+        }
+
+        protected boolean isWorldEnabled(World world) {
+                return world != null && worlds.contains(normalize(world.getName()));
+        }
+
+        protected boolean isWorldEnabled(String worldName) {
+                return worldName != null && worlds.contains(normalize(worldName));
+        }
+
+        protected boolean isSameWorld(World first, World second) {
+                return first != null && first.equals(second);
+        }
+
+        protected Set<String> getConfiguredWorlds() {
+                return worlds;
+        }
+
+        private String normalize(String worldName) {
+                return worldName.trim().toLowerCase(Locale.ROOT);
+        }
+}

--- a/src/main/java/me/lele/worldSafe/listener/blocks/explosioncancel/BedExplosionCancelListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/blocks/explosioncancel/BedExplosionCancelListener.java
@@ -1,23 +1,21 @@
 package me.lele.worldSafe.listener.blocks.explosioncancel;
 
+import me.lele.worldSafe.listener.WorldScopedFeature;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.type.Bed;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 
 import java.util.List;
 
-public class BedExplosionCancelListener implements Listener {
+public class BedExplosionCancelListener extends WorldScopedFeature {
 
-	private final List<String> worlds;
-
-	public BedExplosionCancelListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
+        public BedExplosionCancelListener(List<String> worlds) {
+                super(worlds);
+        }
 
 	@EventHandler
 	void onPlayerInteractEvent(PlayerInteractEvent e) {
@@ -42,14 +40,6 @@ public class BedExplosionCancelListener implements Listener {
                 // 取消事件，防止爆炸
                 e.setCancelled(true);
 
-        }
-
-        private World getWorld(Block block) {
-                return block != null ? block.getWorld() : null;
-        }
-
-        private boolean isWorldEnabled(World world) {
-                return world != null && worlds.contains(world.getName());
         }
 
 }

--- a/src/main/java/me/lele/worldSafe/listener/blocks/explosioncancel/RespawnAnchorExplosionCancelListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/blocks/explosioncancel/RespawnAnchorExplosionCancelListener.java
@@ -1,21 +1,17 @@
 package me.lele.worldSafe.listener.blocks.explosioncancel;
 
-import org.bukkit.Location;
-import org.bukkit.World;
+import me.lele.worldSafe.listener.WorldScopedFeature;
 import org.bukkit.Material;
 import org.bukkit.block.BlockState;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockExplodeEvent;
 
 import java.util.List;
 
-public class RespawnAnchorExplosionCancelListener implements Listener {
-
-    private final List<String> worlds;
+public class RespawnAnchorExplosionCancelListener extends WorldScopedFeature {
 
     public RespawnAnchorExplosionCancelListener(List<String> worlds) {
-        this.worlds = worlds;
+        super(worlds);
     }
 
     @EventHandler
@@ -28,8 +24,7 @@ public class RespawnAnchorExplosionCancelListener implements Listener {
 
         // 检测是否为 重生锚 爆炸
         if (explodedBlockState.getBlockData().getMaterial() == Material.RESPAWN_ANCHOR) {
-            World world = getWorld(explodedBlockState.getLocation());
-            if (!isWorldEnabled(world)) {
+            if (!isWorldEnabled(explodedBlockState.getLocation())) {
                 return;
             }
             // 清空爆炸影响的方块
@@ -38,13 +33,4 @@ public class RespawnAnchorExplosionCancelListener implements Listener {
         }
 
     }
-
-    private World getWorld(Location location) {
-        return location != null ? location.getWorld() : null;
-    }
-
-    private boolean isWorldEnabled(World world) {
-        return world != null && worlds.contains(world.getName());
-    }
-
 }

--- a/src/main/java/me/lele/worldSafe/listener/blocks/explosioncancel/TNTExplosionCancelListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/blocks/explosioncancel/TNTExplosionCancelListener.java
@@ -1,39 +1,26 @@
 package me.lele.worldSafe.listener.blocks.explosioncancel;
 
-import org.bukkit.World;
-import org.bukkit.entity.Entity;
+import me.lele.worldSafe.listener.WorldScopedFeature;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityExplodeEvent;
 
 import java.util.List;
 
-public class TNTExplosionCancelListener implements Listener {
-	private final List<String> worlds;
+public class TNTExplosionCancelListener extends WorldScopedFeature {
 
-	public TNTExplosionCancelListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
+        public TNTExplosionCancelListener(List<String> worlds) {
+                super(worlds);
+        }
 
 	@EventHandler
 	void onTNTExplode(EntityExplodeEvent e) {
-		// 检测是否为TNT类实体
-		if (e.getEntityType() != EntityType.TNT && e.getEntityType() != EntityType.TNT_MINECART)
-			return;
-                Entity ent = e.getEntity();
-                World world = getWorld(ent);
-                if (!isWorldEnabled(world))
+                // 检测是否为TNT类实体
+                if (e.getEntityType() != EntityType.TNT && e.getEntityType() != EntityType.TNT_MINECART)
+                        return;
+                if (!isWorldEnabled(getWorld(e.getEntity())))
                         return;
                 // 清空爆炸影响的方块
                 e.setCancelled(true);
-        }
-
-        private World getWorld(Entity entity) {
-                return entity != null ? entity.getWorld() : null;
-        }
-
-        private boolean isWorldEnabled(World world) {
-                return world != null && worlds.contains(world.getName());
         }
 }

--- a/src/main/java/me/lele/worldSafe/listener/blocks/explosionprevention/BedExplosionProtectionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/blocks/explosionprevention/BedExplosionProtectionListener.java
@@ -1,21 +1,17 @@
 package me.lele.worldSafe.listener.blocks.explosionprevention;
 
-import org.bukkit.Location;
-import org.bukkit.World;
+import me.lele.worldSafe.listener.WorldScopedFeature;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.data.type.Bed;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockExplodeEvent;
 
 import java.util.List;
 
-public class BedExplosionProtectionListener implements Listener {
-
-    private final List<String> worlds;
+public class BedExplosionProtectionListener extends WorldScopedFeature {
 
     public BedExplosionProtectionListener(List<String> worlds) {
-        this.worlds = worlds;
+        super(worlds);
     }
 
     @EventHandler
@@ -28,8 +24,7 @@ public class BedExplosionProtectionListener implements Listener {
 
         // 检测是否为 床 爆炸
         if (explodedBlockState.getBlockData() instanceof Bed){
-            World world = getWorld(explodedBlockState.getLocation());
-            if (!isWorldEnabled(world)) {
+            if (!isWorldEnabled(explodedBlockState.getLocation())) {
                 return;
             }
             // 清空爆炸影响的方块
@@ -38,13 +33,4 @@ public class BedExplosionProtectionListener implements Listener {
         }
 
     }
-
-    private World getWorld(Location location) {
-        return location != null ? location.getWorld() : null;
-    }
-
-    private boolean isWorldEnabled(World world) {
-        return world != null && worlds.contains(world.getName());
-    }
-
 }

--- a/src/main/java/me/lele/worldSafe/listener/blocks/explosionprevention/RespawnAnchorExplosionPreventionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/blocks/explosionprevention/RespawnAnchorExplosionPreventionListener.java
@@ -1,21 +1,17 @@
 package me.lele.worldSafe.listener.blocks.explosionprevention;
 
-import org.bukkit.Location;
-import org.bukkit.World;
+import me.lele.worldSafe.listener.WorldScopedFeature;
 import org.bukkit.Material;
 import org.bukkit.block.BlockState;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockExplodeEvent;
 
 import java.util.List;
 
-public class RespawnAnchorExplosionPreventionListener implements Listener {
-
-    private final List<String> worlds;
+public class RespawnAnchorExplosionPreventionListener extends WorldScopedFeature {
 
     public RespawnAnchorExplosionPreventionListener(List<String> worlds) {
-        this.worlds = worlds;
+        super(worlds);
     }
 
     @EventHandler
@@ -28,8 +24,7 @@ public class RespawnAnchorExplosionPreventionListener implements Listener {
 
         // 检测是否为 重生锚 爆炸
         if (explodedBlockState.getBlockData().getMaterial() == Material.RESPAWN_ANCHOR) {
-            World world = getWorld(explodedBlockState.getLocation());
-            if (!isWorldEnabled(world)) {
+            if (!isWorldEnabled(explodedBlockState.getLocation())) {
                 return;
             }
             // 清空爆炸影响的方块
@@ -38,13 +33,4 @@ public class RespawnAnchorExplosionPreventionListener implements Listener {
         }
 
     }
-
-    private World getWorld(Location location) {
-        return location != null ? location.getWorld() : null;
-    }
-
-    private boolean isWorldEnabled(World world) {
-        return world != null && worlds.contains(world.getName());
-    }
-
 }

--- a/src/main/java/me/lele/worldSafe/listener/blocks/explosionprevention/TNTExplosionProtectionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/blocks/explosionprevention/TNTExplosionProtectionListener.java
@@ -1,39 +1,26 @@
 package me.lele.worldSafe.listener.blocks.explosionprevention;
 
-import java.util.List;
-
-import org.bukkit.World;
-import org.bukkit.entity.Entity;
+import me.lele.worldSafe.listener.WorldScopedFeature;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityExplodeEvent;
 
-public class TNTExplosionProtectionListener implements Listener {
-	private final List<String> worlds;
+import java.util.List;
 
-	public TNTExplosionProtectionListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
+public class TNTExplosionProtectionListener extends WorldScopedFeature {
+
+        public TNTExplosionProtectionListener(List<String> worlds) {
+                super(worlds);
+        }
 
 	@EventHandler
 	void onTNTExplode(EntityExplodeEvent e) {
-		// 检测是否为TNT类实体
-		if (e.getEntityType() != EntityType.TNT && e.getEntityType() != EntityType.TNT_MINECART)
-			return;
-                Entity ent = e.getEntity();
-                World world = getWorld(ent);
-                if (!isWorldEnabled(world))
+                // 检测是否为TNT类实体
+                if (e.getEntityType() != EntityType.TNT && e.getEntityType() != EntityType.TNT_MINECART)
+                        return;
+                if (!isWorldEnabled(getWorld(e.getEntity())))
                         return;
                 // 清空爆炸影响的方块
                 e.blockList().clear();
-        }
-
-        private World getWorld(Entity entity) {
-                return entity != null ? entity.getWorld() : null;
-        }
-
-        private boolean isWorldEnabled(World world) {
-                return world != null && worlds.contains(world.getName());
         }
 }

--- a/src/main/java/me/lele/worldSafe/listener/blocks/other/CropTrampleProtectionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/blocks/other/CropTrampleProtectionListener.java
@@ -1,20 +1,17 @@
 package me.lele.worldSafe.listener.blocks.other;
 
-import java.util.List;
-
+import me.lele.worldSafe.listener.WorldScopedFeature;
 import org.bukkit.Material;
-import org.bukkit.World;
-import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 
-public class CropTrampleProtectionListener implements Listener {
-	private final List<String> worlds;
+import java.util.List;
 
-	public CropTrampleProtectionListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
+public class CropTrampleProtectionListener extends WorldScopedFeature {
+
+        public CropTrampleProtectionListener(List<String> worlds) {
+                super(worlds);
+        }
 
 	@EventHandler
 	void onBlockChangeByEntity(EntityChangeBlockEvent e) {
@@ -22,21 +19,12 @@ public class CropTrampleProtectionListener implements Listener {
 		// 判断是否为耕地
 		if (b.getType() != Material.FARMLAND)
 			return;
-		// 检测是否为踩踏
-		if (e.getTo() != Material.DIRT && e.getTo() != Material.GRASS_BLOCK)
-			return;
-                World world = getWorld(b);
-                if (!isWorldEnabled(world))
+                // 检测是否为踩踏
+                if (e.getTo() != Material.DIRT && e.getTo() != Material.GRASS_BLOCK)
+                        return;
+                if (!isWorldEnabled(getWorld(b)))
                         return;
                 // 取消事件
                 e.setCancelled(true);
-        }
-
-        private World getWorld(Block block) {
-                return block != null ? block.getWorld() : null;
-        }
-
-        private boolean isWorldEnabled(World world) {
-                return world != null && worlds.contains(world.getName());
         }
 }

--- a/src/main/java/me/lele/worldSafe/listener/blocks/other/DragonEggTeleportationPreventionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/blocks/other/DragonEggTeleportationPreventionListener.java
@@ -1,30 +1,28 @@
 package me.lele.worldSafe.listener.blocks.other;
 
-import java.util.List;
-
+import me.lele.worldSafe.listener.WorldScopedFeature;
 import org.bukkit.Material;
-import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockFromToEvent;
 
-public class DragonEggTeleportationPreventionListener implements Listener {
-	private final List<String> worlds;
+import java.util.List;
 
-	public DragonEggTeleportationPreventionListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
+public class DragonEggTeleportationPreventionListener extends WorldScopedFeature {
+
+        public DragonEggTeleportationPreventionListener(List<String> worlds) {
+                super(worlds);
+        }
 
 	@EventHandler
 	void onDragonEggTeleport(BlockFromToEvent e) {
-		Block b = e.getBlock();
-		// 检测方块是否为龙蛋
-		if (b.getType() != Material.DRAGON_EGG)
-			return;
-		// 判断是否启动这个世界
-		if (!worlds.contains(b.getWorld().getName()))
-			return;
-		// 取消事件 即禁止龙蛋瞬移
-		e.setCancelled(true);
-	}
+                Block b = e.getBlock();
+                // 检测方块是否为龙蛋
+                if (b.getType() != Material.DRAGON_EGG)
+                        return;
+                // 判断是否启动这个世界
+                if (!isWorldEnabled(getWorld(b)))
+                        return;
+                // 取消事件 即禁止龙蛋瞬移
+                e.setCancelled(true);
+        }
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/explosioncancel/CreeperExplosionCancelListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/explosioncancel/CreeperExplosionCancelListener.java
@@ -1,44 +1,27 @@
 package me.lele.worldSafe.listener.entities.explosioncancel;
 
-import org.bukkit.Location;
-import org.bukkit.World;
+import me.lele.worldSafe.listener.WorldScopedFeature;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityExplodeEvent;
 
 import java.util.List;
 
-public class CreeperExplosionCancelListener implements Listener {
+public class CreeperExplosionCancelListener extends WorldScopedFeature {
 
-	// 定义生效的世界
-	private final List<String> worlds;
+        public CreeperExplosionCancelListener(List<String> worlds) {
+                super(worlds);
+        }
 
-	// 把配置文件中的生效世界赋值到worlds
-	public CreeperExplosionCancelListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
-
-	@EventHandler
-	public void onCreeperExplode(EntityExplodeEvent event) {
-		// 检查是否是Creeper的爆炸
-		if (event.getEntityType() == EntityType.CREEPER) {
-			// 获取事件触发的世界
-                        World world = getWorld(event.getLocation());
-                        if (!isWorldEnabled(world)) {
+        @EventHandler
+        public void onCreeperExplode(EntityExplodeEvent event) {
+                // 检查是否是Creeper的爆炸
+                if (event.getEntityType() == EntityType.CREEPER) {
+                        if (!isWorldEnabled(event.getLocation())) {
                                 return;
                         }
                         // 阻止事件
                         event.setCancelled(true);
                 }
         }
-
-        private World getWorld(Location location) {
-                return location != null ? location.getWorld() : null;
-        }
-
-        private boolean isWorldEnabled(World world) {
-                return world != null && worlds.contains(world.getName());
-        }
-
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/explosioncancel/EndCrystalExplosionCancelListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/explosioncancel/EndCrystalExplosionCancelListener.java
@@ -1,29 +1,24 @@
 package me.lele.worldSafe.listener.entities.explosioncancel;
 
-import org.bukkit.Location;
-import org.bukkit.World;
+import me.lele.worldSafe.listener.WorldScopedFeature;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityExplodeEvent;
 
 import java.util.List;
 
-public class EndCrystalExplosionCancelListener implements Listener {
-
-    private final List<String> worlds;
+public class EndCrystalExplosionCancelListener extends WorldScopedFeature {
 
     public EndCrystalExplosionCancelListener(List<String> worlds) {
-        this.worlds = worlds;
+        super(worlds);
     }
 
     @EventHandler
     public void onEntityExplode(EntityExplodeEvent event) {
         // 检查爆炸实体是否是末地水晶
         if (isEndCrystal(event.getEntity())) {
-            World world = getWorld(event.getLocation());
-            if (!isWorldEnabled(world)) {
+            if (!isWorldEnabled(event.getLocation())) {
                 return;
             }
             // 清空爆炸影响的方块
@@ -33,14 +28,6 @@ public class EndCrystalExplosionCancelListener implements Listener {
 
     private boolean isEndCrystal(Entity entity) {
         return entity != null && entity.getType() == EntityType.END_CRYSTAL;
-    }
-
-    private World getWorld(Location location) {
-        return location != null ? location.getWorld() : null;
-    }
-
-    private boolean isWorldEnabled(World world) {
-        return world != null && worlds.contains(world.getName());
     }
 
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/explosioncancel/GhastExplosionCancelListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/explosioncancel/GhastExplosionCancelListener.java
@@ -1,22 +1,20 @@
 package me.lele.worldSafe.listener.entities.explosioncancel;
 
-import org.bukkit.World;
+import me.lele.worldSafe.listener.WorldScopedFeature;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Fireball;
 import org.bukkit.entity.Ghast;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 
 import java.util.List;
 
-public class GhastExplosionCancelListener implements Listener {
-	private final List<String> worlds;
+public class GhastExplosionCancelListener extends WorldScopedFeature {
 
-	public GhastExplosionCancelListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
+        public GhastExplosionCancelListener(List<String> worlds) {
+                super(worlds);
+        }
 
 	@EventHandler
 	void onFileballExplode(EntityExplodeEvent e) {
@@ -24,8 +22,7 @@ public class GhastExplosionCancelListener implements Listener {
 		if (e.getEntityType() != EntityType.FIREBALL)
 			return;
                 Fireball ent = (Fireball) e.getEntity();
-                World world = getWorld(ent);
-                if (!isWorldEnabled(world))
+                if (!isWorldEnabled(getWorld(ent)))
                         return;
                 // 检测是否为恶魂发出的火球
                 if (!(ent.getShooter() instanceof Ghast))
@@ -40,8 +37,7 @@ public class GhastExplosionCancelListener implements Listener {
 		if (e.getDamager().getType() != EntityType.FIREBALL)
 			return;
                 Fireball ent = (Fireball) e.getDamager();
-                World world = getWorld(ent);
-                if (!isWorldEnabled(world))
+                if (!isWorldEnabled(getWorld(ent)))
                         return;
                 // 检测是否为恶魂发出的火球
                 if (!(ent.getShooter() instanceof Ghast))
@@ -50,11 +46,4 @@ public class GhastExplosionCancelListener implements Listener {
                 e.setCancelled(true);
         }
 
-        private World getWorld(Fireball fireball) {
-                return fireball != null ? fireball.getWorld() : null;
-        }
-
-        private boolean isWorldEnabled(World world) {
-                return world != null && worlds.contains(world.getName());
-        }
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/explosioncancel/WitherExplosionCancelListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/explosioncancel/WitherExplosionCancelListener.java
@@ -1,39 +1,26 @@
 package me.lele.worldSafe.listener.entities.explosioncancel;
 
-import java.util.List;
-
-import org.bukkit.World;
-import org.bukkit.entity.Entity;
+import me.lele.worldSafe.listener.WorldScopedFeature;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityExplodeEvent;
 
-public class WitherExplosionCancelListener implements Listener {
-	private final List<String> worlds;
+import java.util.List;
 
-	public WitherExplosionCancelListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
+public class WitherExplosionCancelListener extends WorldScopedFeature {
+
+        public WitherExplosionCancelListener(List<String> worlds) {
+                super(worlds);
+        }
 
 	@EventHandler
 	void onExplode(EntityExplodeEvent e) {
 		// 检测是否为凋零/凋零头颅
 		if (e.getEntityType() != EntityType.WITHER && e.getEntityType() != EntityType.WITHER_SKULL)
 			return;
-                Entity ent = e.getEntity();
-                World world = getWorld(ent);
-                if (!isWorldEnabled(world))
+                if (!isWorldEnabled(getWorld(e.getEntity())))
                         return;
                 // 取消事件 阻止爆炸
                 e.setCancelled(true);
-        }
-
-        private World getWorld(Entity entity) {
-                return entity != null ? entity.getWorld() : null;
-        }
-
-        private boolean isWorldEnabled(World world) {
-                return world != null && worlds.contains(world.getName());
         }
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/explosionprevention/CreeperExplosionProtectionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/explosionprevention/CreeperExplosionProtectionListener.java
@@ -1,43 +1,27 @@
 package me.lele.worldSafe.listener.entities.explosionprevention;
 
-import org.bukkit.Location;
-import org.bukkit.World;
+import me.lele.worldSafe.listener.WorldScopedFeature;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityExplodeEvent;
 
 import java.util.List;
 
-public class CreeperExplosionProtectionListener implements Listener {
+public class CreeperExplosionProtectionListener extends WorldScopedFeature {
 
-	// 定义生效的世界
-	private final List<String> worlds;
+        public CreeperExplosionProtectionListener(List<String> worlds) {
+                super(worlds);
+        }
 
-	// 把配置文件中的生效世界赋值到worlds
-	public CreeperExplosionProtectionListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
-
-	@EventHandler
+        @EventHandler
         public void onCreeperExplode(EntityExplodeEvent event) {
                 // 检查是否是Creeper的爆炸
                 if (event.getEntityType() == EntityType.CREEPER) {
-                        World world = getWorld(event.getLocation());
-                        if (!isWorldEnabled(world)) {
+                        if (!isWorldEnabled(event.getLocation())) {
                                 return;
                         }
                         // 阻止事件
                         event.blockList().clear();
                 }
         }
-
-        private World getWorld(Location location) {
-                return location != null ? location.getWorld() : null;
-        }
-
-        private boolean isWorldEnabled(World world) {
-                return world != null && worlds.contains(world.getName());
-        }
-
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/explosionprevention/EndCrystalExplosionPreventionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/explosionprevention/EndCrystalExplosionPreventionListener.java
@@ -1,29 +1,24 @@
 package me.lele.worldSafe.listener.entities.explosionprevention;
 
-import org.bukkit.Location;
-import org.bukkit.World;
+import me.lele.worldSafe.listener.WorldScopedFeature;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityExplodeEvent;
 
 import java.util.List;
 
-public class EndCrystalExplosionPreventionListener implements Listener {
-
-    private final List<String> worlds;
+public class EndCrystalExplosionPreventionListener extends WorldScopedFeature {
 
     public EndCrystalExplosionPreventionListener(List<String> worlds) {
-        this.worlds = worlds;
+        super(worlds);
     }
 
     @EventHandler
     public void onEntityExplode(EntityExplodeEvent event) {
         // 检查爆炸实体是否是末地水晶
         if (isEndCrystal(event.getEntity())) {
-            World world = getWorld(event.getLocation());
-            if (!isWorldEnabled(world)) {
+            if (!isWorldEnabled(event.getLocation())) {
                 return;
             }
             // 清空爆炸影响的方块
@@ -33,14 +28,6 @@ public class EndCrystalExplosionPreventionListener implements Listener {
 
     private boolean isEndCrystal(Entity entity) {
         return entity != null && entity.getType() == EntityType.END_CRYSTAL;
-    }
-
-    private World getWorld(Location location) {
-        return location != null ? location.getWorld() : null;
-    }
-
-    private boolean isWorldEnabled(World world) {
-        return world != null && worlds.contains(world.getName());
     }
 
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/explosionprevention/GhastExplosionProtectionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/explosionprevention/GhastExplosionProtectionListener.java
@@ -1,21 +1,19 @@
 package me.lele.worldSafe.listener.entities.explosionprevention;
 
-import java.util.List;
-
-import org.bukkit.World;
+import me.lele.worldSafe.listener.WorldScopedFeature;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Fireball;
 import org.bukkit.entity.Ghast;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityExplodeEvent;
 
-public class GhastExplosionProtectionListener implements Listener {
-	private final List<String> worlds;
+import java.util.List;
 
-	public GhastExplosionProtectionListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
+public class GhastExplosionProtectionListener extends WorldScopedFeature {
+
+        public GhastExplosionProtectionListener(List<String> worlds) {
+                super(worlds);
+        }
 
 	@EventHandler
 	void onFileballExplode(EntityExplodeEvent e) {
@@ -23,21 +21,12 @@ public class GhastExplosionProtectionListener implements Listener {
 		if (e.getEntityType() != EntityType.FIREBALL)
 			return;
                 Fireball ent = (Fireball) e.getEntity();
-                World world = getWorld(ent);
-                if (!isWorldEnabled(world))
+                if (!isWorldEnabled(getWorld(ent)))
                         return;
                 // 检测是否为恶魂发出的火球
                 if (!(ent.getShooter() instanceof Ghast))
                         return;
                 // 清空受影响的方块
                 e.blockList().clear();
-        }
-
-        private World getWorld(Fireball fireball) {
-                return fireball != null ? fireball.getWorld() : null;
-        }
-
-        private boolean isWorldEnabled(World world) {
-                return world != null && worlds.contains(world.getName());
         }
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/explosionprevention/WitherExplosionProtectionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/explosionprevention/WitherExplosionProtectionListener.java
@@ -1,55 +1,34 @@
 package me.lele.worldSafe.listener.entities.explosionprevention;
 
-import java.util.List;
-
+import me.lele.worldSafe.listener.WorldScopedFeature;
 import org.bukkit.Material;
 import org.bukkit.World;
-import org.bukkit.block.Block;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 
-public class WitherExplosionProtectionListener implements Listener {
-	private final List<String> worlds;
+import java.util.List;
 
-	public WitherExplosionProtectionListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
+public class WitherExplosionProtectionListener extends WorldScopedFeature {
+
+        public WitherExplosionProtectionListener(List<String> worlds) {
+                super(worlds);
+        }
 
 	@EventHandler
 	void onWitherDestroyBlock(EntityChangeBlockEvent e) {
-		// 判断是否为凋零/凋零头
-		if (e.getEntityType() != EntityType.WITHER && e.getEntityType() != EntityType.WITHER_SKULL)
-			return;
-                Entity ent = e.getEntity();
-                World entityWorld = getWorld(ent);
+                // 判断是否为凋零/凋零头
+                if (e.getEntityType() != EntityType.WITHER && e.getEntityType() != EntityType.WITHER_SKULL)
+                        return;
+                World entityWorld = getWorld(e.getEntity());
                 if (!isWorldEnabled(entityWorld))
                         return;
-                World blockWorld = getWorld(e.getBlock());
-                if (!isSameWorld(entityWorld, blockWorld))
+                if (!isSameWorld(entityWorld, getWorld(e.getBlock())))
                         return;
                 // 判断是否破坏方块
                 if (e.getTo() != Material.AIR)
                         return;
                 // 取消事件
                 e.setCancelled(true);
-        }
-
-        private World getWorld(Entity entity) {
-                return entity != null ? entity.getWorld() : null;
-        }
-
-        private World getWorld(Block block) {
-                return block != null ? block.getWorld() : null;
-        }
-
-        private boolean isSameWorld(World first, World second) {
-                return first != null && first.equals(second);
-        }
-
-        private boolean isWorldEnabled(World world) {
-                return world != null && worlds.contains(world.getName());
         }
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/other/EnderDragonBlockDestructionProtectionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/other/EnderDragonBlockDestructionProtectionListener.java
@@ -1,55 +1,34 @@
 package me.lele.worldSafe.listener.entities.other;
 
-import java.util.List;
-
+import me.lele.worldSafe.listener.WorldScopedFeature;
 import org.bukkit.Material;
 import org.bukkit.World;
-import org.bukkit.block.Block;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 
-public class EnderDragonBlockDestructionProtectionListener implements Listener {
-	private final List<String> worlds;
+import java.util.List;
 
-	public EnderDragonBlockDestructionProtectionListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
+public class EnderDragonBlockDestructionProtectionListener extends WorldScopedFeature {
+
+        public EnderDragonBlockDestructionProtectionListener(List<String> worlds) {
+                super(worlds);
+        }
 
 	@EventHandler
 	void onEnderDragonDestroyBlock(EntityChangeBlockEvent e) {
-		// 判断是否为末影龙
-		if (e.getEntityType() != EntityType.ENDER_DRAGON)
-			return;
-                Entity ed = e.getEntity();
-                World dragonWorld = getWorld(ed);
+                // 判断是否为末影龙
+                if (e.getEntityType() != EntityType.ENDER_DRAGON)
+                        return;
+                World dragonWorld = getWorld(e.getEntity());
                 if (!isWorldEnabled(dragonWorld))
                         return;
-                World blockWorld = getWorld(e.getBlock());
-                if (!isSameWorld(dragonWorld, blockWorld))
+                if (!isSameWorld(dragonWorld, getWorld(e.getBlock())))
                         return;
                 // 判断是否破坏方块
                 if (e.getTo() != Material.AIR)
                         return;
                 // 取消事件
                 e.setCancelled(true);
-        }
-
-        private World getWorld(Entity entity) {
-                return entity != null ? entity.getWorld() : null;
-        }
-
-        private World getWorld(Block block) {
-                return block != null ? block.getWorld() : null;
-        }
-
-        private boolean isSameWorld(World first, World second) {
-                return first != null && first.equals(second);
-        }
-
-        private boolean isWorldEnabled(World world) {
-                return world != null && worlds.contains(world.getName());
         }
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/other/EnderManBlockPickupProtectionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/other/EnderManBlockPickupProtectionListener.java
@@ -1,32 +1,24 @@
 package me.lele.worldSafe.listener.entities.other;
 
-import org.bukkit.World;
-import org.bukkit.block.Block;
+import me.lele.worldSafe.listener.WorldScopedFeature;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 
 import java.util.List;
 
-public class EnderManBlockPickupProtectionListener implements Listener {
+public class EnderManBlockPickupProtectionListener extends WorldScopedFeature {
 
-	// 定义生效的世界
-	private final List<String> worlds;
-
-	// 把配置文件中的生效世界赋值到worlds
-	public EnderManBlockPickupProtectionListener(List<String> worlds) {
-		this.worlds = worlds;
-	}
+        public EnderManBlockPickupProtectionListener(List<String> worlds) {
+                super(worlds);
+        }
 
 	@EventHandler
 	public void onEnderManBlockPickup(EntityChangeBlockEvent event) {
-		// 检查是否是末影人
-		if (event.getEntityType() == EntityType.ENDERMAN) {
-			// 获取事件触发的世界
-                        Block block = event.getBlock();
-                        World world = getWorld(block);
-                        if (!isWorldEnabled(world)) {
+                // 检查是否是末影人
+                if (event.getEntityType() == EntityType.ENDERMAN) {
+                        // 获取事件触发的世界
+                        if (!isWorldEnabled(getWorld(event.getBlock()))) {
                                 return;
                         }
                         // 阻止事件
@@ -35,13 +27,4 @@ public class EnderManBlockPickupProtectionListener implements Listener {
                 }
 
         }
-
-        private World getWorld(Block block) {
-                return block != null ? block.getWorld() : null;
-        }
-
-        private boolean isWorldEnabled(World world) {
-                return world != null && worlds.contains(world.getName());
-        }
-
 }

--- a/src/main/java/me/lele/worldSafe/listener/entities/other/PhantomDamagePreventionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/entities/other/PhantomDamagePreventionListener.java
@@ -1,22 +1,17 @@
 package me.lele.worldSafe.listener.entities.other;
 
-import org.bukkit.World;
+import me.lele.worldSafe.listener.WorldScopedFeature;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 
 import java.util.List;
 
-public class PhantomDamagePreventionListener implements Listener {
+public class PhantomDamagePreventionListener extends WorldScopedFeature {
 
-    // 定义生效的世界
-    private final List<String> worlds;
-
-    // 把配置文件中的生效世界赋值到worlds
     public PhantomDamagePreventionListener(List<String> worlds) {
-        this.worlds = worlds;
+        super(worlds);
     }
 
     @EventHandler
@@ -26,8 +21,7 @@ public class PhantomDamagePreventionListener implements Listener {
         if (!isPhantom(damager))
             return;
         // 检测此世界是否启用
-        World world = getWorld(damager);
-        if (!isWorldEnabled(world))
+        if (!isWorldEnabled(getWorld(damager)))
             return;
         //消除幻翼伤害
         e.setCancelled(true);
@@ -35,14 +29,6 @@ public class PhantomDamagePreventionListener implements Listener {
 
     private boolean isPhantom(Entity entity) {
         return entity != null && entity.getType() == EntityType.PHANTOM;
-    }
-
-    private World getWorld(Entity entity) {
-        return entity != null ? entity.getWorld() : null;
-    }
-
-    private boolean isWorldEnabled(World world) {
-        return world != null && worlds.contains(world.getName());
     }
 
 }


### PR DESCRIPTION
## Summary
- add a reusable `WorldScopedFeature` base class that normalizes configured world names and exposes helper methods for world lookups
- update all block and entity listeners to extend the shared base and unify their world filtering logic

## Testing
- `mvn -q -DskipTests package` *(fails: unable to download maven-resources-plugin because the repository returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68fa4c7aa1e483309692b0e460f3f6c1