### PR TITLE
Add fire spread prevention feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Reload the plugin configuration
 
 - ✅ **cropTrampleProtection** - Prevent crops from being trampled
 - ✅ **dragonEggTeleportationPrevention** - Prevent dragon egg teleportation
+- ✅ **fireSpreadPrevention** - Prevent fire from spreading between blocks
 
 ## 🧬 Entity Classes
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -58,6 +58,7 @@
 
 - ✅ **cropTrampleProtection** - 禁止田被踩坏
 - ✅ **dragonEggTeleportationPrevention** - 禁止龙蛋瞬移
+- ✅ **fireSpreadPrevention** - 禁止火焰向周围方块蔓延
 
 ## 🧬 实体类
 

--- a/src/main/java/me/lele/worldSafe/WorldSafe.java
+++ b/src/main/java/me/lele/worldSafe/WorldSafe.java
@@ -12,6 +12,7 @@ import me.lele.worldSafe.listener.blocks.explosionprevention.RespawnAnchorExplos
 import me.lele.worldSafe.listener.blocks.explosionprevention.TNTExplosionProtectionListener;
 import me.lele.worldSafe.listener.blocks.other.CropTrampleProtectionListener;
 import me.lele.worldSafe.listener.blocks.other.DragonEggTeleportationPreventionListener;
+import me.lele.worldSafe.listener.blocks.other.FireSpreadPreventionListener;
 import me.lele.worldSafe.listener.entities.explosioncancel.CreeperExplosionCancelListener;
 import me.lele.worldSafe.listener.entities.explosioncancel.EndCrystalExplosionCancelListener;
 import me.lele.worldSafe.listener.entities.explosioncancel.GhastExplosionCancelListener;
@@ -55,6 +56,7 @@ public final class WorldSafe extends JavaPlugin {
                         entry("tntExplosionProtection", TNTExplosionProtectionListener::new),
                         entry("cropTrampleProtection", CropTrampleProtectionListener::new),
                         entry("dragonEggTeleportationPrevention", DragonEggTeleportationPreventionListener::new),
+                        entry("fireSpreadPrevention", FireSpreadPreventionListener::new),
                         entry("creeperExplosionCancel", CreeperExplosionCancelListener::new),
                         entry("endCrystalExplosionCancel", EndCrystalExplosionCancelListener::new),
                         entry("ghastExplosionCancel", GhastExplosionCancelListener::new),

--- a/src/main/java/me/lele/worldSafe/listener/blocks/other/FireSpreadPreventionListener.java
+++ b/src/main/java/me/lele/worldSafe/listener/blocks/other/FireSpreadPreventionListener.java
@@ -1,0 +1,43 @@
+package me.lele.worldSafe.listener.blocks.other;
+
+import me.lele.worldSafe.listener.WorldScopedFeature;
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.block.BlockIgniteEvent;
+import org.bukkit.event.block.BlockSpreadEvent;
+
+import java.util.List;
+
+public class FireSpreadPreventionListener extends WorldScopedFeature {
+
+        public FireSpreadPreventionListener(List<String> worlds) {
+                super(worlds);
+        }
+
+        @EventHandler(ignoreCancelled = true)
+        void onFireSpread(BlockSpreadEvent event) {
+                if (!isFire(event.getNewState().getType())) {
+                        return;
+                }
+                if (!isWorldEnabled(getWorld(event.getBlock()))) {
+                        return;
+                }
+                event.setCancelled(true);
+        }
+
+        @EventHandler(ignoreCancelled = true)
+        void onBlockIgnite(BlockIgniteEvent event) {
+                if (!isWorldEnabled(getWorld(event.getBlock()))) {
+                        return;
+                }
+
+                BlockIgniteEvent.IgniteCause cause = event.getCause();
+                if (cause == BlockIgniteEvent.IgniteCause.SPREAD || cause == BlockIgniteEvent.IgniteCause.LAVA) {
+                        event.setCancelled(true);
+                }
+        }
+
+        private boolean isFire(Material material) {
+                return material == Material.FIRE || material == Material.SOUL_FIRE;
+        }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -24,3 +24,7 @@ tntExplosionProtection:
   - world
   - world_nether
   - world_the_end
+
+# Fire Spread Prevention / 防止火焰蔓延
+fireSpreadPrevention:
+  - world


### PR DESCRIPTION
## Summary
- add a configurable listener that prevents fire spread by cancelling fire spread and ignite events in enabled worlds
- register the feature and document the new configuration option in both README files and the sample config

## Testing
- ⚠️ `mvn -q -DskipTests package` *(fails: Maven cannot download plugins in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fd9f5e2da88330933e518ddd331f33